### PR TITLE
Identify remaining stars

### DIFF
--- a/src/attitude-utils.cpp
+++ b/src/attitude-utils.cpp
@@ -155,6 +155,12 @@ float ArcSecToRad(float arcSec) {
     return DegToRad(arcSec / 3600.0);
 }
 
+float FloatModulo(float x, float mod) {
+    // first but not last chatgpt generated code in lost:
+    float result = x - mod * floor(x / mod);
+    return result >= 0 ? result : result + mod;
+}
+
 /// The square of the magnitude
 float Vec3::MagnitudeSq() const {
     return x*x+y*y+z*z;

--- a/src/attitude-utils.cpp
+++ b/src/attitude-utils.cpp
@@ -163,20 +163,20 @@ float FloatModulo(float x, float mod) {
 
 /// The square of the magnitude
 float Vec3::MagnitudeSq() const {
-    return x*x+y*y+z*z;
+    return fma(x,x,fma(y,y, z*z));
 }
 
 /// The square of the magnitude
 float Vec2::MagnitudeSq() const {
-    return x*x+y*y;
+    return fma(x,x, y*y);
 }
 
 float Vec3::Magnitude() const {
-    return sqrt(MagnitudeSq());
+    return hypot(hypot(x, y), z); // not sure if this is faster than a simple sqrt, but it does have less error?
 }
 
 float Vec2::Magnitude() const {
-    return sqrt(MagnitudeSq());
+    return hypot(x, y);
 }
 
 /// Create a vector pointing in the same direction with magnitude 1
@@ -189,7 +189,7 @@ Vec3 Vec3::Normalize() const {
 
 /// Dot product
 float Vec3::operator*(const Vec3 &other) const {
-    return x*other.x + y*other.y + z*other.z;
+    return fma(x,other.x, fma(y,other.y, z*other.z));
 }
 
 /// Dot product

--- a/src/attitude-utils.hpp
+++ b/src/attitude-utils.hpp
@@ -169,6 +169,9 @@ float RadToDeg(float);
 float DegToRad(float);
 float RadToArcSec(float);
 float ArcSecToRad(float);
+/// Given a float, find it "modulo" another float, in the true mathematical sense (not remainder).
+/// Always returns something in [0,mod) Eg -0.8 mod 0.6 = 0.4
+float FloatModulo(float x, float mod);
 
 // TODO: quaternion and euler angle conversion, conversion between ascension/declination to rec9tu
 

--- a/src/databases.cpp
+++ b/src/databases.cpp
@@ -268,6 +268,8 @@ float Clamp(float num, float low, float high) {
 const int16_t *PairDistanceKVectorDatabase::FindPairsLiberal(
     float minQueryDistance, float maxQueryDistance, const int16_t **end) const {
 
+    assert(maxQueryDistance <= M_PI);
+
     long upperIndex = -1;
     long lowerIndex = index.QueryLiberal(minQueryDistance, maxQueryDistance, &upperIndex);
     *end = &pairs[upperIndex * 2];
@@ -276,20 +278,30 @@ const int16_t *PairDistanceKVectorDatabase::FindPairsLiberal(
 
 const int16_t *PairDistanceKVectorDatabase::FindPairsExact(const Catalog &catalog,
                                                            float minQueryDistance, float maxQueryDistance, const int16_t **end) const {
+
+    // Instead of computing the angle for every pair in the database, we pre-compute the /cosines/
+    // of the min and max query distances so that we can compare against dot products directly! As
+    // angle increases, cosine decreases, up to M_PI (and queries larger than that don't really make
+    // sense anyway)
+    assert(maxQueryDistance <= M_PI);
+
+    float maxQueryCos = cos(minQueryDistance);
+    float minQueryCos = cos(maxQueryDistance);
+
     long liberalUpperIndex;
     long liberalLowerIndex = index.QueryLiberal(minQueryDistance, maxQueryDistance, &liberalUpperIndex);
     // now we need to find the first and last index that actually matches the query
     // step the lower index forward
+    // There's no good reason to be using >= and <= for the comparison against max/min, but the tests fail otherwise (because they use angle, with its acos, instead of forward cos like us). It's an insignificant difference.
     while (liberalLowerIndex < liberalUpperIndex
-             && AngleUnit(catalog[pairs[liberalLowerIndex*2]].spatial,
-                          catalog[pairs[liberalLowerIndex*2+1]].spatial) < minQueryDistance
+           && catalog[pairs[liberalLowerIndex*2]].spatial * catalog[pairs[liberalLowerIndex*2+1]].spatial >= maxQueryCos
         )
     { liberalLowerIndex++; }
+
     // step the upper index backward
     while (liberalLowerIndex < liberalUpperIndex
            // the liberalUpperIndex is past the end of the logically returned range, so we need to subtract 1
-           && AngleUnit(catalog[pairs[(liberalUpperIndex-1)*2]].spatial,
-                        catalog[pairs[(liberalUpperIndex-1)*2+1]].spatial) > maxQueryDistance
+           && catalog[pairs[(liberalUpperIndex-1)*2]].spatial * catalog[pairs[(liberalUpperIndex-1)*2+1]].spatial <= minQueryCos
         )
     { liberalUpperIndex--; }
 

--- a/src/databases.cpp
+++ b/src/databases.cpp
@@ -274,6 +274,28 @@ const int16_t *PairDistanceKVectorDatabase::FindPairsLiberal(
     return &pairs[lowerIndex * 2];
 }
 
+const int16_t *PairDistanceKVectorDatabase::FindPairsExact(const Catalog &catalog,
+                                                           float minQueryDistance, float maxQueryDistance, const int16_t **end) const {
+    long liberalUpperIndex;
+    long liberalLowerIndex = index.QueryLiberal(minQueryDistance, maxQueryDistance, &liberalUpperIndex);
+    // now we need to find the first and last index that actually matches the query
+    // step the lower index forward
+    while (liberalLowerIndex < liberalUpperIndex
+             && AngleUnit(catalog[pairs[liberalLowerIndex*2]].spatial,
+                          catalog[pairs[liberalLowerIndex*2+1]].spatial) < minQueryDistance
+        )
+    { liberalLowerIndex++; }
+    // step the upper index backward
+    while (liberalLowerIndex < liberalUpperIndex
+           && AngleUnit(catalog[pairs[liberalUpperIndex*2]].spatial,
+                        catalog[pairs[liberalUpperIndex*2+1]].spatial) > maxQueryDistance
+        )
+    { liberalUpperIndex--; }
+
+    *end = &pairs[liberalUpperIndex * 2];
+    return &pairs[liberalLowerIndex * 2];
+}
+
 /// Number of star pairs stored in the database
 long PairDistanceKVectorDatabase::NumPairs() const {
     return index.NumValues();

--- a/src/databases.cpp
+++ b/src/databases.cpp
@@ -287,8 +287,9 @@ const int16_t *PairDistanceKVectorDatabase::FindPairsExact(const Catalog &catalo
     { liberalLowerIndex++; }
     // step the upper index backward
     while (liberalLowerIndex < liberalUpperIndex
-           && AngleUnit(catalog[pairs[liberalUpperIndex*2]].spatial,
-                        catalog[pairs[liberalUpperIndex*2+1]].spatial) > maxQueryDistance
+           // the liberalUpperIndex is past the end of the logically returned range, so we need to subtract 1
+           && AngleUnit(catalog[pairs[(liberalUpperIndex-1)*2]].spatial,
+                        catalog[pairs[(liberalUpperIndex-1)*2+1]].spatial) > maxQueryDistance
         )
     { liberalUpperIndex--; }
 

--- a/src/databases.hpp
+++ b/src/databases.hpp
@@ -12,7 +12,7 @@ namespace lost {
 const int32_t kCatalogMagicValue = 0xF9A283BC;
 
 /**
- * A data structure enabling constant-time range queries into fixed numerica data.
+ * A data structure enabling constant-time range queries into fixed numerical data.
  * 
  * @note Not an instantiable database on its own -- used in other databases
  */

--- a/src/databases.hpp
+++ b/src/databases.hpp
@@ -54,6 +54,7 @@ public:
     explicit PairDistanceKVectorDatabase(const unsigned char *databaseBytes);
 
     const int16_t *FindPairsLiberal(float min, float max, const int16_t **end) const;
+    const int16_t *FindPairsExact(const Catalog &, float min, float max, const int16_t **end) const;
     std::vector<float> StarDistances(int16_t star, const Catalog &) const;
 
     /// Upper bound on stored star pair distances

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -993,6 +993,10 @@ StarIdComparison StarIdsCompare(const StarIdentifiers &expected, const StarIdent
 
     sort(expectedSorted.begin(), expectedSorted.end(), StarIdCompare);
     sort(actualSorted.begin(), actualSorted.end(), StarIdCompare);
+    // throw an error if any duplicates in actualSorted
+    for (int i = 1; i < (int)actualSorted.size(); i++) {
+        assert(actualSorted[i].starIndex != actualSorted[i-1].starIndex);
+    }
 
     auto currActual = actualSorted.cbegin();
     for (const StarIdentifier &currExpected : expectedSorted) {

--- a/src/star-id-private.hpp
+++ b/src/star-id-private.hpp
@@ -14,9 +14,10 @@ namespace lost {
 /// The "angles" through here are "triangular angles". A triangular angle is a 2D angle in a triangle formed by three centroids.
 class IRUnidentifiedCentroid {
 public:
-    IRUnidentifiedCentroid(const Star &star)
+    IRUnidentifiedCentroid(const Star &star, int16_t index)
         : bestAngleFrom90(std::numeric_limits<float>::max()), // should be infinity
           bestStar1(0,0), bestStar2(0,0),
+          index(index),
           star(&star) { }
 
     float bestAngleFrom90; /// For the pair of other centroids forming the triangular angle closest to 90 degrees, how far from 90 degrees it is (in radians)
@@ -45,6 +46,7 @@ std::vector<int16_t> IdentifyThirdStar(const PairDistanceKVectorDatabase &db,
 int IdentifyRemainingStarsPairDistance(StarIdentifiers *,
                                        const Stars &,
                                        const PairDistanceKVectorDatabase &,
+                                       const Catalog &,
                                        const Camera &,
                                        float tolerance);
 

--- a/src/star-id-private.hpp
+++ b/src/star-id-private.hpp
@@ -3,10 +3,12 @@
 #ifndef STAR_ID_PRIVATE_H
 #define STAR_ID_PRIVATE_H
 
+#include <limits>
+#include <utility>
+#include <vector>
+
 #include "star-id.hpp"
 #include "databases.hpp"
-
-#include <limits>
 
 namespace lost {
 
@@ -19,7 +21,7 @@ public:
           bestStar1(0,0), bestStar2(0,0),
           index(index),
           star(&star) {
-        identifiedStarsInRange.reserve(10);
+        identifiedStarsInRange.reserve(10); // this does quite measurably improve performance, at least on desktop
     }
 
     // "null" has index=-1

--- a/src/star-id-private.hpp
+++ b/src/star-id-private.hpp
@@ -20,6 +20,11 @@ public:
           index(index),
           star(&star) { }
 
+    // "null" has index=-1
+    IRUnidentifiedCentroid()
+        : bestStar1(0,0), bestStar2(0,0),
+          index(-1) { }
+
     float bestAngleFrom90; /// For the pair of other centroids forming the triangular angle closest to 90 degrees, how far from 90 degrees it is (in radians)
     StarIdentifier bestStar1; /// One star corresponding to bestAngleFrom90
     StarIdentifier bestStar2; /// The other star corresponding to bestAngleFrom90

--- a/src/star-id-private.hpp
+++ b/src/star-id-private.hpp
@@ -18,7 +18,9 @@ public:
         : bestAngleFrom90(std::numeric_limits<float>::max()), // should be infinity
           bestStar1(0,0), bestStar2(0,0),
           index(index),
-          star(&star) { }
+          star(&star) {
+        identifiedStarsInRange.reserve(10);
+    }
 
     // "null" has index=-1
     IRUnidentifiedCentroid()

--- a/src/star-id-private.hpp
+++ b/src/star-id-private.hpp
@@ -1,0 +1,51 @@
+// Stuff that tests need to access, but not part of the public interface
+
+#ifndef STAR_ID_PRIVATE_H
+#define STAR_ID_PRIVATE_H
+
+#include "star-id.hpp"
+#include "databases.hpp"
+
+#include <limits>
+
+namespace lost {
+
+/// unidentified centroid used in IdentifyRemainingStarsPairDistance
+/// The "angles" through here are "triangular angles". A triangular angle is a 2D angle in a triangle formed by three centroids.
+class IRUnidentifiedCentroid {
+public:
+    IRUnidentifiedCentroid(const Star &star)
+        : bestAngleFrom90(std::numeric_limits<float>::max()), // should be infinity
+          bestStar1(0,0), bestStar2(0,0),
+          star(&star) { }
+
+    float bestAngleFrom90; /// For the pair of other centroids forming the triangular angle closest to 90 degrees, how far from 90 degrees it is (in radians)
+    StarIdentifier bestStar1; /// One star corresponding to bestAngleFrom90
+    StarIdentifier bestStar2; /// The other star corresponding to bestAngleFrom90
+    int16_t index; /// Index into list of all centroids
+    const Star *star;
+
+private:
+    // possible improvement: Use a tree map here to allow binary search
+    std::vector<std::pair<float, StarIdentifier>> identifiedStarsInRange;
+
+private:
+    float VerticalAnglesToAngleFrom90(float v1, float v2);
+
+public:
+    /**
+     * When a centroid within range of this centroid is identified, call this function. This
+     * function does /not/ check whether the centroid is within range.
+     */
+    void AddIdentifiedStar(const StarIdentifier &starId, const Stars &stars);
+};
+
+int IdentifyRemainingStarsPairDistance(StarIdentifiers *,
+                                       const Stars &,
+                                       const PairDistanceKVectorDatabase &,
+                                       const Camera &,
+                                       float tolerance);
+
+}
+
+#endif

--- a/src/star-id-private.hpp
+++ b/src/star-id-private.hpp
@@ -33,12 +33,14 @@ private:
     float VerticalAnglesToAngleFrom90(float v1, float v2);
 
 public:
-    /**
-     * When a centroid within range of this centroid is identified, call this function. This
-     * function does /not/ check whether the centroid is within range.
-     */
     void AddIdentifiedStar(const StarIdentifier &starId, const Stars &stars);
 };
+
+std::vector<int16_t> IdentifyThirdStar(const PairDistanceKVectorDatabase &db,
+                                       const Catalog &catalog,
+                                       int16_t catalogIndex1, int16_t catalogIndex2,
+                                       float distance1, float distance2,
+                                       float tolerance);
 
 int IdentifyRemainingStarsPairDistance(StarIdentifiers *,
                                        const Stars &,

--- a/src/star-id.cpp
+++ b/src/star-id.cpp
@@ -294,27 +294,27 @@ public:
 };
 
 std::vector<IRUnidentifiedCentroid *> FindUnidentifiedCentroidsInRange(std::vector<IRUnidentifiedCentroid> *centroids, const Star &star, float minDistance, float maxDistance) {
-    std::vector<IRUnidentifiedCentroid *> result;
+    // std::vector<IRUnidentifiedCentroid *> result;
 
-    // Find the first centroid that is within range of the given centroid.
-    auto firstInRange = std::lower_bound(centroids->begin(), centroids->end(), star.position.x - maxDistance,
-        [](const IRUnidentifiedCentroid &centroid, float x) {
-            return centroid.star.position.x < x;
-        });
+    // // Find the first centroid that is within range of the given centroid.
+    // auto firstInRange = std::lower_bound(centroids->begin(), centroids->end(), star.position.x - maxDistance,
+    //     [](const IRUnidentifiedCentroid &centroid, float x) {
+    //         return centroid.star.position.x < x;
+    //     });
 
-    // Find the first centroid that is not within range of the given centroid.
-    auto firstNotInRange = std::lower_bound(firstInRange, centroids->end(), star.position.x + maxDistance,
-        [](const IRUnidentifiedCentroid &centroid, float x) {
-            return centroid.star.position.x <= x;
-        });
+    // // Find the first centroid that is not within range of the given centroid.
+    // auto firstNotInRange = std::lower_bound(firstInRange, centroids->end(), star.position.x + maxDistance,
+    //     [](const IRUnidentifiedCentroid &centroid, float x) {
+    //         return centroid.star.position.x <= x;
+    //     });
 
-    // Copy the pointers to the stars into the result vector.
-    for (auto it = firstInRange; it != firstNotInRange; ++it) {
-        float distance = Distance(star.position, it->star.position);
-        if (distance >= minDistance && distance <= maxDistance) {
-            result.push_back(&*it);
-        }
-    }
+    // // Copy the pointers to the stars into the result vector.
+    // for (auto it = firstInRange; it != firstNotInRange; ++it) {
+    //     float distance = Distance(star.position, it->star.position);
+    //     if (distance >= minDistance && distance <= maxDistance) {
+    //         result.push_back(&*it);
+    //     }
+    // }
 
     return result;
 }
@@ -340,7 +340,6 @@ void AddToAllUnidentifiedCentroids(const StarIdentifier &starId, const Stars &st
  */
 int IdentifyRemainingStarsPairDistance(StarIdentifiers *identifiers,
                                         const Stars &stars,
-                                        const Catalog &catalog,
                                         const PairDistanceKVectorDatabase &db,
                                         const Camera &camera,
                                         float tolerance) {

--- a/src/star-id.cpp
+++ b/src/star-id.cpp
@@ -396,8 +396,8 @@ int IdentifyRemainingStarsPairDistance(StarIdentifiers *identifiers,
                                        float tolerance) {
     // initialize all unidentified centroids
     std::vector<IRUnidentifiedCentroid> unidentifiedCentroids;
-    for (const Star &star : stars) {
-        unidentifiedCentroids.push_back(IRUnidentifiedCentroid(star));
+    for (size_t i = 0; i < stars.size(); i++) {
+        unidentifiedCentroids.push_back(IRUnidentifiedCentroid(stars[i], i));
     }
 
     // sort unidentified centroids by x coordinate

--- a/src/star-utils.cpp
+++ b/src/star-utils.cpp
@@ -34,13 +34,13 @@ Catalog NarrowCatalog(const Catalog &catalog, int maxMagnitude, int maxStars) {
 }
 
 /// Return a pointer to the star with the given name, or NULL if not found.
-const CatalogStar *FindNamedStar(const Catalog &catalog, int name) {
-    for (const CatalogStar &catalogStar : catalog) {
-        if (catalogStar.name == name) {
-            return &catalogStar;
+Catalog::const_iterator FindNamedStar(const Catalog &catalog, int name) {
+    for (auto it = catalog.cbegin(); it != catalog.cend(); ++it) {
+        if (it->name == name) {
+            return it;
         }
     }
-    return NULL;
+    return catalog.cend();
 }
 
 /// @sa SerializeCatalogStar

--- a/src/star-utils.hpp
+++ b/src/star-utils.hpp
@@ -82,6 +82,12 @@ public:
     StarIdentifier(int starIndex, int catalogIndex)
         : StarIdentifier(starIndex, catalogIndex, 1.0f) { };
 
+    // does not check weight
+    bool operator==(const StarIdentifier& other) const {
+        return starIndex == other.starIndex &&
+            catalogIndex == other.catalogIndex;
+    }
+
     /// An index into an array of Star objects.
     int starIndex;
     /// An index into an array of CatalogStar objects.

--- a/src/star-utils.hpp
+++ b/src/star-utils.hpp
@@ -104,7 +104,7 @@ long SerializeLengthCatalog(const Catalog &, bool inclMagnitude, bool inclName);
 void SerializeCatalog(const Catalog &, bool inclMagnitude, bool inclName, unsigned char *buffer);
 // sets magnited and name to whether the catalog in the database contained magnitude and name
 Catalog DeserializeCatalog(const unsigned char *buffer, bool *inclMagnitudeReturn, bool *inclNameReturn);
-const CatalogStar *FindNamedStar(const Catalog &, int name);
+Catalog::const_iterator FindNamedStar(const Catalog &catalog, int name);
 
 // TODO: make maxStars work right, need to sort by magnitude before filter! maxMagnitude is 10^-2
 // (so 523 = 5.23)

--- a/test/fixtures.cpp
+++ b/test/fixtures.cpp
@@ -6,7 +6,10 @@
 #include "attitude-utils.hpp"
 #include "camera.hpp"
 
-using namespace lost; // NOLINT
+#include "fixtures.hpp"
+
+// TODO: here and in utils.cpp, probably shouldn't actually be putting stuff into the lost namespace.
+namespace lost {
 
 // three stars that should be easy to identify based on their distances to each other
 Catalog tripleCatalog = {
@@ -31,7 +34,7 @@ Catalog harderQuadrupleCatalog = {
 };
 
 Catalog integralCatalog = {
-    CatalogStar(0, 0, 3.0, 42), // (0,0,0)
+    CatalogStar(0, 0, 3.0, 42), // (1,0,0)
     CatalogStar(M_PI_4, 0, 3.0, 43), // (.707,.707,0)
     CatalogStar(M_PI_2, 0, 3.0, 44), // (0,1,0)
     CatalogStar(3 * M_PI_4, 0, 3.0, 45), // (-.707,.707,0)
@@ -49,6 +52,12 @@ Catalog integralCatalog = {
     CatalogStar(3 * M_PI_4, -M_PI_4, 3.0, 57), // (-.5,.5,-.707)
 
     CatalogStar(0, -M_PI_2, 3.0, 58), // (0,0,-1)
+};
+
+Catalog nearlyColinearCatalog = {
+    CatalogStar(0, 0, 3.0, 42), // (1,0,0)
+    CatalogStar(0, DegToRad(1.0), 3.0, 43), // little bit above
+    CatalogStar(DegToRad(0.01), DegToRad(2.0), 3.0, 44), // above and a bit to the right
 };
 
 Camera smolCamera(FovToFocalLength(DegToRad(36.0), 256), 256, 256);
@@ -84,3 +93,5 @@ StarIdentifiers elevenStarIds = {
     StarIdentifier(10, 10, 1),
     StarIdentifier(11, 11, 1),
 };
+
+}

--- a/test/fixtures.cpp
+++ b/test/fixtures.cpp
@@ -1,0 +1,86 @@
+// unlike most files in this folder, there /is/ a fixtures.hpp that must be kept up-to-date with this file.
+
+#include <math.h>
+
+#include "star-utils.hpp"
+#include "attitude-utils.hpp"
+#include "camera.hpp"
+
+using namespace lost; // NOLINT
+
+// three stars that should be easy to identify based on their distances to each other
+Catalog tripleCatalog = {
+    CatalogStar(DegToRad(2), DegToRad(-3), 3.0, 42),
+    CatalogStar(DegToRad(4), DegToRad(7), 2.0, 43),
+    CatalogStar(DegToRad(2), DegToRad(6), 4.0, 44),
+};
+
+Catalog quadrupleCatalog = {
+    CatalogStar(DegToRad(2), DegToRad(-3), 3.0, 42),
+    CatalogStar(DegToRad(4), DegToRad(7), 2.0, 43),
+    CatalogStar(DegToRad(2), DegToRad(6), 4.0, 44),
+    CatalogStar(DegToRad(-1), DegToRad(-4), 1.0, 45),
+};
+
+// distance between 42/43 == distance between 44/45, have to use distances to 43 to differentiate
+Catalog harderQuadrupleCatalog = {
+    CatalogStar(DegToRad(2), DegToRad(-3), 3.0, 42),
+    CatalogStar(DegToRad(4), DegToRad(7), 2.0, 43),
+    CatalogStar(DegToRad(2), DegToRad(5), 4.0, 44),
+    CatalogStar(DegToRad(2), DegToRad(1), 1.0, 45),
+};
+
+Catalog integralCatalog = {
+    CatalogStar(0, 0, 3.0, 42), // (0,0,0)
+    CatalogStar(M_PI_4, 0, 3.0, 43), // (.707,.707,0)
+    CatalogStar(M_PI_2, 0, 3.0, 44), // (0,1,0)
+    CatalogStar(3 * M_PI_4, 0, 3.0, 45), // (-.707,.707,0)
+
+    CatalogStar(0, M_PI_4, 3.0, 46), // (.707,0,.707)
+    CatalogStar(M_PI_4, M_PI_4, 3.0, 47), // (.5,.5,.707)
+    CatalogStar(M_PI_2, M_PI_4, 3.0, 48), // (0,.707,.707)
+    CatalogStar(3 * M_PI_4, M_PI_4, 3.0, 49), // (-.5,.5,.707)
+
+    CatalogStar(0, M_PI_2, 3.0, 50), // (0,0,1)
+
+    CatalogStar(0, -M_PI_4, 3.0, 54), // (.707,0,-.707)
+    CatalogStar(M_PI_4, -M_PI_4, 3.0, 55), // (.5,.5,-.707)
+    CatalogStar(M_PI_2, -M_PI_4, 3.0, 56), // (0,.707,-.707)
+    CatalogStar(3 * M_PI_4, -M_PI_4, 3.0, 57), // (-.5,.5,-.707)
+
+    CatalogStar(0, -M_PI_2, 3.0, 58), // (0,0,-1)
+};
+
+Camera smolCamera(FovToFocalLength(DegToRad(36.0), 256), 256, 256);
+Camera smolCameraOff(FovToFocalLength(DegToRad(33.0), 256), 256, 256);
+Quaternion straightAhead(1.0, 0.0, 0.0, 0.0);
+
+Stars elevenStars = {
+    Star(0, 0, 1), // 0
+    Star(1, 0, 1), // 1
+    Star(0, 1, 1), // 2
+    Star(1, 1, 1), // 3
+    Star(2, 0, 1), // 4
+    Star(2, 1, 1), // 5
+    Star(2, 2, 1), // 6
+    Star(3, 0, 1), // 7
+    Star(3, 1, 1), // 8
+    Star(3, 2, 1), // 9
+    Star(3, 3, 1), // 10
+    Star(1, 3, 1), // 11
+};
+
+StarIdentifiers elevenStarIds = {
+    StarIdentifier(0, 0, 1),
+    StarIdentifier(1, 1, 1),
+    StarIdentifier(2, 2, 1),
+    StarIdentifier(3, 3, 1),
+    StarIdentifier(4, 4, 1),
+    StarIdentifier(5, 5, 1),
+    StarIdentifier(6, 6, 1),
+    StarIdentifier(7, 7, 1),
+    StarIdentifier(8, 8, 1),
+    StarIdentifier(9, 9, 1),
+    StarIdentifier(10, 10, 1),
+    StarIdentifier(11, 11, 1),
+};

--- a/test/fixtures.hpp
+++ b/test/fixtures.hpp
@@ -1,0 +1,24 @@
+#ifndef FIXTURES_H
+#define FIXTURES_H
+
+#include "star-utils.hpp"
+#include "attitude-utils.hpp"
+#include "camera.hpp"
+
+namespace lost {
+
+extern Catalog tripleCatalog;
+extern Catalog quadrupleCatalog;
+extern Catalog harderQuadrupleCatalog;
+extern Catalog integralCatalog;
+
+extern Camera smolCamera;
+extern Camera smolCameraOff;
+extern Quaternion straightAhead;
+
+extern Stars elevenStars;
+extern StarIdentifiers elevenStarIds;
+
+}
+
+#endif

--- a/test/fixtures.hpp
+++ b/test/fixtures.hpp
@@ -11,6 +11,7 @@ extern Catalog tripleCatalog;
 extern Catalog quadrupleCatalog;
 extern Catalog harderQuadrupleCatalog;
 extern Catalog integralCatalog;
+extern Catalog nearlyColinearCatalog;
 
 extern Camera smolCamera;
 extern Camera smolCameraOff;

--- a/test/geometric-voting.cpp.off
+++ b/test/geometric-voting.cpp.off
@@ -9,34 +9,9 @@
 #include "star-utils.hpp"
 #include "camera.hpp"
 #include "io.hpp"
+#include "fixtures.h"
 
 using namespace lost;
-
-// three stars that should be easy to identify based on their distances to each other
-Catalog tripleCatalog = {
-    CatalogStar(DegToRad(2), DegToRad(-3), 3.0, 42),
-    CatalogStar(DegToRad(4), DegToRad(7), 2.0, 43),
-    CatalogStar(DegToRad(2), DegToRad(6), 4.0, 44),
-};
-
-Catalog quadrupleCatalog = {
-    CatalogStar(DegToRad(2), DegToRad(-3), 3.0, 42),
-    CatalogStar(DegToRad(4), DegToRad(7), 2.0, 43),
-    CatalogStar(DegToRad(2), DegToRad(6), 4.0, 44),
-    CatalogStar(DegToRad(-1), DegToRad(-4), 1.0, 45),
-};
-
-// distance between 42/43 == distance between 44/45, have to use distances to 43 to differentiate
-Catalog harderQuadrupleCatalog = {
-    CatalogStar(DegToRad(2), DegToRad(-3), 3.0, 42),
-    CatalogStar(DegToRad(4), DegToRad(7), 2.0, 43),
-    CatalogStar(DegToRad(2), DegToRad(5), 4.0, 44),
-    CatalogStar(DegToRad(2), DegToRad(1), 1.0, 45),
-};
-
-Camera smolCamera(FovToFocalLength(DegToRad(36.0), 256), 256, 256);
-Camera smolCameraOff(FovToFocalLength(DegToRad(33.0), 256), 256, 256);
-Quaternion straightAhead(1.0, 0.0, 0.0, 0.0);
 
 TEST_CASE("Tres Commas", "[gv] [fast]") {
     // TODO: Check that both stars receive exactly 2 votes, there's no reason for them to get 1 vote each!

--- a/test/identify-remaining-stars.cpp
+++ b/test/identify-remaining-stars.cpp
@@ -1,0 +1,55 @@
+#include <catch.hpp>
+
+#include "star-id.cpp"
+
+using namespace lost; // NOLINT
+
+Stars stars = {
+    Star(0, 0, 1), // 0
+    Star(1, 0, 1), // 1
+    Star(0, 1, 1), // 2
+    Star(1, 1, 1), // 3
+    Star(2, 0, 1), // 4
+    Star(2, 1, 1), // 5
+    Star(2, 2, 1), // 6
+    Star(3, 0, 1), // 7
+    Star(3, 1, 1), // 8
+    Star(3, 2, 1), // 9
+    Star(3, 3, 1), // 10
+    Star(1, 3, 1), // 11
+};
+
+StarIdentifiers starIdentifiers = {
+    StarIdentifier(0, 0, 1),
+    StarIdentifier(1, 1, 1),
+    StarIdentifier(2, 2, 1),
+    StarIdentifier(3, 3, 1),
+    StarIdentifier(4, 4, 1),
+    StarIdentifier(5, 5, 1),
+    StarIdentifier(6, 6, 1),
+    StarIdentifier(7, 7, 1),
+    StarIdentifier(8, 8, 1),
+    StarIdentifier(9, 9, 1),
+    StarIdentifier(10, 10, 1),
+    StarIdentifier(11, 11, 1),
+};
+
+TEST_CASE("IRUnidentifiedCentroid simple orthogonal", "[identify-remaining]") {
+    IRUnidentifiedCentroid centroid(stars[3]);
+    REQUIRE(centroid.bestAngleFrom90 == -1);
+    centroid.AddIdentifiedStar(starIdentifiers[1], stars);
+    // one star is not enough to get angle
+    REQUIRE(centroid.bestAngleFrom90 == -1);
+    centroid.AddIdentifiedStar(starIdentifiers[2], stars);
+    // we've set them up to be almost orthogonal
+    REQUIRE(centroid.bestAngleFrom90 == Approx(0));
+    REQUIRE(centroid.bestStar1 == starIdentifiers[1] && centroid.bestStar2 == starIdentifiers[2] ||
+            centroid.bestStar1 == starIdentifiers[2] && centroid.bestStar2 == starIdentifiers[1]);
+
+    // adding another, non-orthogonal one shouldn't break it
+    centroid.AddIdentifiedStar(starIdentifiers[0], stars);
+    REQUIRE(centroid.bestAngleFrom90 == Approx(0));
+    REQUIRE(centroid.bestStar1 == starIdentifiers[1] && centroid.bestStar2 == starIdentifiers[2] ||
+            centroid.bestStar1 == starIdentifiers[2] && centroid.bestStar2 == starIdentifiers[1]);
+}
+

--- a/test/identify-remaining-stars.cpp
+++ b/test/identify-remaining-stars.cpp
@@ -129,15 +129,13 @@ TEST_CASE("IdentifyThirdStar just out of tolerance", "[identify-remaining] [fast
 
 #define kIdentifyRemainingNumImages 10
 
-TEST_CASE("IdentifyRemainingStars fuzz", "[identify-remaining] [fast]") {
+TEST_CASE("IdentifyRemainingStars fuzz", "[identify-remaining] [fuzz]") {
 
     // generate a whole bunch of centroids, project all to 3d to create a fake catalog, create
     // kvector,then choose a few randomly to pre-identify, and then ensure the rest are all
     // identified. To ensure there's no ambiguity, we always increment the x-value. This results in
     // a weird triangular distribution of stars, but that's better than nothing!
     int numFakeStars = 100;
-
-    std::cout << "new scenario" << std::endl;
 
     std::default_random_engine rng(GENERATE(take(kIdentifyRemainingNumImages, random(0, 1000000))));
     std::uniform_real_distribution<float> yDist(0.0, 256.0);
@@ -167,10 +165,10 @@ TEST_CASE("IdentifyRemainingStars fuzz", "[identify-remaining] [fast]") {
 
     int numIdentified = IdentifyRemainingStarsPairDistance(&someFakeStarIds, fakeCentroids, db, fakeCatalog, smolCamera, 1e-6);
 
+    delete[] dbBytes;
+
     REQUIRE(numIdentified == numFakeStars - 2);
     REQUIRE(AreStarIdentifiersEquivalent(fakeStarIds, someFakeStarIds));
-
-    delete[] dbBytes;
 }
 
 // TODO: Test if kvector MaxDistance is substantially less than FOV

--- a/test/identify-remaining-stars.cpp
+++ b/test/identify-remaining-stars.cpp
@@ -158,21 +158,19 @@ TEST_CASE("IdentifyRemainingStars fuzz", "[identify-remaining] [fuzz]") {
     StarIdentifiers fakeStarIdsCopy = fakeStarIds;
     std::shuffle(fakeStarIdsCopy.begin(), fakeStarIdsCopy.end(), rng);
     StarIdentifiers someFakeStarIds;
-    someFakeStarIds.push_back(fakeStarIdsCopy[0]);
-    someFakeStarIds.push_back(fakeStarIdsCopy[1]);
-    if (moreStartingStars(rng)) {
-        someFakeStarIds.push_back(fakeStarIdsCopy[2]);
-        someFakeStarIds.push_back(fakeStarIdsCopy[3]);
+    int fakePatternSize = moreStartingStars(rng) ? 4 : 2;
+    for (int i = 0; i < fakePatternSize; i++) {
+        someFakeStarIds.push_back(fakeStarIdsCopy[i]);
     }
 
     unsigned char *dbBytes = BuildPairDistanceKVectorDatabase(fakeCatalog, NULL, 0, M_PI, 1000);
     PairDistanceKVectorDatabase db(dbBytes);
 
-    int numIdentified = IdentifyRemainingStarsPairDistance(&someFakeStarIds, fakeCentroids, db, fakeCatalog, smolCamera, 1e-6);
+    int numIdentified = IdentifyRemainingStarsPairDistance(&someFakeStarIds, fakeCentroids, db, fakeCatalog, smolCamera, 1e-5);
 
     delete[] dbBytes;
 
-    REQUIRE(numIdentified == numFakeStars - 2);
+    REQUIRE(numIdentified == numFakeStars - fakePatternSize);
     REQUIRE(AreStarIdentifiersEquivalent(fakeStarIds, someFakeStarIds));
 }
 

--- a/test/identify-remaining-stars.cpp
+++ b/test/identify-remaining-stars.cpp
@@ -1,6 +1,6 @@
-#include <catch.hpp>
-
 #include <random>
+
+#include <catch.hpp>
 
 #include "star-id.hpp"
 #include "star-id-private.hpp"
@@ -49,7 +49,7 @@ TEST_CASE("IRUnidentifiedCentroid obtuse angle", "[identify-remaining] [fast]") 
 
 // TODO: Tests for FindAllInRange if we ever make the logic more complicated
 
-std::vector<int16_t> IdentifyThirdStarTest(Catalog &catalog, int16_t catalogName1, int16_t catalogName2,
+std::vector<int16_t> IdentifyThirdStarTest(const Catalog &catalog, int16_t catalogName1, int16_t catalogName2,
                                            float dist1, float dist2, float tolerance) {
     unsigned char *dbBytes = BuildPairDistanceKVectorDatabase(integralCatalog, NULL, 0, M_PI, 1000);
     auto cs1 = FindNamedStar(catalog, catalogName1);

--- a/test/identify-remaining-stars.cpp
+++ b/test/identify-remaining-stars.cpp
@@ -1,55 +1,92 @@
 #include <catch.hpp>
 
-#include "star-id.cpp"
+#include "star-id.hpp"
+#include "star-id-private.hpp"
+
+#include "fixtures.hpp"
 
 using namespace lost; // NOLINT
 
-Stars stars = {
-    Star(0, 0, 1), // 0
-    Star(1, 0, 1), // 1
-    Star(0, 1, 1), // 2
-    Star(1, 1, 1), // 3
-    Star(2, 0, 1), // 4
-    Star(2, 1, 1), // 5
-    Star(2, 2, 1), // 6
-    Star(3, 0, 1), // 7
-    Star(3, 1, 1), // 8
-    Star(3, 2, 1), // 9
-    Star(3, 3, 1), // 10
-    Star(1, 3, 1), // 11
-};
-
-StarIdentifiers starIdentifiers = {
-    StarIdentifier(0, 0, 1),
-    StarIdentifier(1, 1, 1),
-    StarIdentifier(2, 2, 1),
-    StarIdentifier(3, 3, 1),
-    StarIdentifier(4, 4, 1),
-    StarIdentifier(5, 5, 1),
-    StarIdentifier(6, 6, 1),
-    StarIdentifier(7, 7, 1),
-    StarIdentifier(8, 8, 1),
-    StarIdentifier(9, 9, 1),
-    StarIdentifier(10, 10, 1),
-    StarIdentifier(11, 11, 1),
-};
-
-TEST_CASE("IRUnidentifiedCentroid simple orthogonal", "[identify-remaining]") {
-    IRUnidentifiedCentroid centroid(stars[3]);
-    REQUIRE(centroid.bestAngleFrom90 == -1);
-    centroid.AddIdentifiedStar(starIdentifiers[1], stars);
+TEST_CASE("IRUnidentifiedCentroid simple orthogonal", "[identify-remaining] [fast]") {
+    IRUnidentifiedCentroid centroid(elevenStars[3]);
+    REQUIRE(centroid.bestAngleFrom90 > 9e9);
+    centroid.AddIdentifiedStar(elevenStarIds[1], elevenStars);
     // one star is not enough to get angle
-    REQUIRE(centroid.bestAngleFrom90 == -1);
-    centroid.AddIdentifiedStar(starIdentifiers[2], stars);
+    REQUIRE(centroid.bestAngleFrom90 > 9e9);
+    centroid.AddIdentifiedStar(elevenStarIds[2], elevenStars);
     // we've set them up to be almost orthogonal
-    REQUIRE(centroid.bestAngleFrom90 == Approx(0));
-    REQUIRE(centroid.bestStar1 == starIdentifiers[1] && centroid.bestStar2 == starIdentifiers[2] ||
-            centroid.bestStar1 == starIdentifiers[2] && centroid.bestStar2 == starIdentifiers[1]);
+    REQUIRE(centroid.bestAngleFrom90 == Approx(0).margin(1e-6));
+    REQUIRE(((centroid.bestStar1 == elevenStarIds[1] && centroid.bestStar2 == elevenStarIds[2]) ||
+             (centroid.bestStar1 == elevenStarIds[2] && centroid.bestStar2 == elevenStarIds[1])));
 
     // adding another, non-orthogonal one shouldn't break it
-    centroid.AddIdentifiedStar(starIdentifiers[0], stars);
-    REQUIRE(centroid.bestAngleFrom90 == Approx(0));
-    REQUIRE(centroid.bestStar1 == starIdentifiers[1] && centroid.bestStar2 == starIdentifiers[2] ||
-            centroid.bestStar1 == starIdentifiers[2] && centroid.bestStar2 == starIdentifiers[1]);
+    centroid.AddIdentifiedStar(elevenStarIds[0], elevenStars);
+    REQUIRE(centroid.bestAngleFrom90 == Approx(0).margin(1e-6));
+    REQUIRE(((centroid.bestStar1 == elevenStarIds[1] && centroid.bestStar2 == elevenStarIds[2]) ||
+             (centroid.bestStar1 == elevenStarIds[2] && centroid.bestStar2 == elevenStarIds[1])));
+}
+
+TEST_CASE("IRUnidentifiedCentroid not orthogonal until they are", "[identify-remaining] [fast]") {
+    IRUnidentifiedCentroid centroid(elevenStars[3]);
+    centroid.AddIdentifiedStar(elevenStarIds[1], elevenStars);
+    centroid.AddIdentifiedStar(elevenStarIds[0], elevenStars);
+    REQUIRE(centroid.bestAngleFrom90 == Approx(M_PI_4));
+    centroid.AddIdentifiedStar(elevenStarIds[6], elevenStars);
+    REQUIRE(centroid.bestAngleFrom90 == Approx(M_PI_4));
+    centroid.AddIdentifiedStar(elevenStarIds[8], elevenStars);
+    REQUIRE(centroid.bestAngleFrom90 == Approx(0).margin(1e-6));
+}
+
+TEST_CASE("IRUnidentifiedCentroid obtuse angle", "[identify-remaining] [fast]") {
+    IRUnidentifiedCentroid centroid(elevenStars[3]);
+    centroid.AddIdentifiedStar(elevenStarIds[1], elevenStars);
+    centroid.AddIdentifiedStar(elevenStarIds[6], elevenStars);
+    REQUIRE(centroid.bestAngleFrom90 == Approx(M_PI_4));
+}
+
+// TODO: Tests for FindAllInRange if we ever make the logic more complicated
+
+TEST_CASE("IdentifyThirdStar simple case (does require spectrality)", "[identify-remaining] [fast]") { // TODO: does it /really/ logically belong with identify-remaining? Maybe we should coin a new term for star pattern identification related functions
+    std::vector<int16_t> stars = IdentifyThirdStar(integralCatalog,
+                                                   Vec3(0,0,0), Vec3(0,1,0),
+                                                   1.0, sqrt(2.0),
+                                                   1e-6);
+    REQUIRE(stars.size() == 1);
+    REQUIRE(integralCatalog[stars[0]].name == 50);
+}
+
+TEST_CASE("IdentifyThirdStar tolerance", "[identify-remaining] [fast]") {
+    // try it again where we actually need the tolerance
+    std::vector<int16_t> stars2 = IdentifyThirdStar(integralCatalog,
+                                                    Vec3(0,0,0), Vec3(0,1,0),
+                                                    0.99, sqrt(2.0) + 0.02,
+                                                    0.1);
+    REQUIRE(stars.size() == 1);
+    REQUIRE(integralCatalog[stars[0]].name == 50);
+}
+
+TEST_CASE("IdentifyThirdStar reversed spectrality", "[identify-remaining] [fast]") {
+    std::vector<int16_t> stars = IdentifyThirdStar(integralCatalog,
+                                                    Vec3(0,1,0), Vec3(0,0,0),
+                                                    sqrt(2.0), 1.0,
+                                                    1e-6);
+    REQUIRE(stars.size() == 1);
+    REQUIRE(integralCatalog[stars[0]].name == 58);
+}
+
+TEST_CASE("IdentifyThirdStar no third star", "[identify-remaining] [fast]") {
+    std::vector<int16_t> stars = IdentifyThirdStar(integralCatalog,
+                                                    Vec3(0,0,0), Vec3(0,1,0),
+                                                    0.5, sqrt(2.0),
+                                                    1e-6);
+    REQUIRE(stars.size() == 0);
+}
+
+TEST_CASE("IdentifyThirdStar just out of tolerance", "[identify-remaining] [fast]") {
+    std::vector<int16_t> stars2 = IdentifyThirdStar(integralCatalog,
+                                                    Vec3(0,0,0), Vec3(0,1,0),
+                                                    0.99, sqrt(2.0),
+                                                    1e-6);
+    REQUIRE(stars2.size() == 0);
 }
 

--- a/test/identify-remaining-stars.cpp
+++ b/test/identify-remaining-stars.cpp
@@ -140,6 +140,7 @@ TEST_CASE("IdentifyRemainingStars fuzz", "[identify-remaining] [fuzz]") {
     std::default_random_engine rng(GENERATE(take(kIdentifyRemainingNumImages, random(0, 1000000))));
     std::uniform_real_distribution<float> yDist(0.0, 256.0);
     std::uniform_int_distribution<int> starIndexDist(0, numFakeStars - 1);
+    std::uniform_int_distribution<int> moreStartingStars(0, 1);
 
     Stars fakeCentroids;
     StarIdentifiers fakeStarIds;
@@ -159,6 +160,10 @@ TEST_CASE("IdentifyRemainingStars fuzz", "[identify-remaining] [fuzz]") {
     StarIdentifiers someFakeStarIds;
     someFakeStarIds.push_back(fakeStarIdsCopy[0]);
     someFakeStarIds.push_back(fakeStarIdsCopy[1]);
+    if (moreStartingStars(rng)) {
+        someFakeStarIds.push_back(fakeStarIdsCopy[2]);
+        someFakeStarIds.push_back(fakeStarIdsCopy[3]);
+    }
 
     unsigned char *dbBytes = BuildPairDistanceKVectorDatabase(fakeCatalog, NULL, 0, M_PI, 1000);
     PairDistanceKVectorDatabase db(dbBytes);

--- a/test/kvector.cpp
+++ b/test/kvector.cpp
@@ -4,20 +4,9 @@
 #include "io.hpp"
 #include "attitude-utils.hpp"
 
+#include "utils.hpp"
+
 using namespace lost; // NOLINT
-
-static unsigned char *BuildPairDistanceKVectorDatabase(
-    const Catalog &catalog, long *length, float minDistance, float maxDistance, long numBins) {
-
-    long dummyLength;
-    if (length == NULL)
-        length = &dummyLength;
-
-    *length = SerializeLengthPairDistanceKVector(catalog, minDistance, maxDistance, numBins);
-    unsigned char *result = new unsigned char[*length];
-    SerializePairDistanceKVector(catalog, minDistance, maxDistance, numBins, result);
-    return result;
-}
 
 TEST_CASE("Kvector full database stuff", "[kvector]") {
     long length;

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -1,3 +1,5 @@
+#include "utils.hpp"
+
 #include <algorithm>
 
 #include "databases.hpp"

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -1,0 +1,33 @@
+#include <algorithm>
+
+#include "databases.hpp"
+
+namespace lost {
+
+unsigned char *BuildPairDistanceKVectorDatabase(
+    const Catalog &catalog, long *length, float minDistance, float maxDistance, long numBins) {
+
+    long dummyLength;
+    if (length == NULL)
+        length = &dummyLength;
+
+    *length = SerializeLengthPairDistanceKVector(catalog, minDistance, maxDistance, numBins);
+    unsigned char *result = new unsigned char[*length];
+    SerializePairDistanceKVector(catalog, minDistance, maxDistance, numBins, result);
+    return result;
+}
+
+bool AreStarIdentifiersEquivalent(const StarIdentifiers &ids1, const StarIdentifiers &ids2) {
+    if (ids1.size() != ids2.size()) {
+        return false;
+    }
+
+    for (const StarIdentifier &id1 : ids1) {
+        if (std::find(ids2.cbegin(), ids2.cend(), id1) == ids2.cend()) {
+            return false;
+        }
+    }
+    return true;
+}
+
+}

--- a/test/utils.hpp
+++ b/test/utils.hpp
@@ -1,0 +1,14 @@
+#ifndef TEST_UTILS_H
+#define TEST_UTILS_H
+
+#include "databases.hpp"
+
+namespace lost {
+
+unsigned char *BuildPairDistanceKVectorDatabase(const Catalog &catalog, long *length, float minDistance, float maxDistance, long numBins);
+/// simple O(n^2) check
+bool AreStarIdentifiersEquivalent(const StarIdentifiers &, const StarIdentifiers &);
+
+}
+
+#endif


### PR DESCRIPTION
Rewrite the identify remaining stars functions and add tests.

Remaining TODOs:
+ Improve performance, probably by using a soft threshold instead of finding the optimal pair to use to identify each star.
+ Diagnose why there are so many duplicate stars matched during pyramid-incorrect.sh