### PR TITLE
Rewrite most of how serialization/deserialization works.

### DIFF
--- a/documentation/database.man
+++ b/documentation/database.man
@@ -83,6 +83,14 @@ Sets the number of distance bins in the kvector building method to \fInum-bins\f
 .SH OTHER OPTIONS
 
 .TP
+\fB--swap-integer-endianness\fP
+If true, generate databases with all integer values having opposite endianness than the generating machine. It will not be possible to use the generated databases on the system they were generated on.
+
+.TP
+\fB--swap-float-endianness\fP
+If true, generate databases with all floating point values having opposite endianness than the generating machine. It will not be possible to use the generated databases on the system they were generated on.
+
+.TP
 \fB--output\fP \fIoutput-path\fP
 The file to output the database to. Defaults to stdout.
 

--- a/src/attitude-utils.cpp
+++ b/src/attitude-utils.cpp
@@ -449,10 +449,10 @@ bool Attitude::IsKnown() const {
 }
 
 /// Serialize a Vec3 to buffer. Takes up space according to SerializeLengthVec3
-void SerializeVec3(std::vector<unsigned char> *buffer, const Vec3 &vec) {
-    SerializePrimitive<float>(buffer, vec.x);
-    SerializePrimitive<float>(buffer, vec.y);
-    SerializePrimitive<float>(buffer, vec.z);
+void SerializeVec3(SerializeContext *ser, const Vec3 &vec) {
+    SerializePrimitive<float>(ser, vec.x);
+    SerializePrimitive<float>(ser, vec.y);
+    SerializePrimitive<float>(ser, vec.z);
 }
 
 Vec3 DeserializeVec3(DeserializeContext *des) {

--- a/src/attitude-utils.cpp
+++ b/src/attitude-utils.cpp
@@ -4,6 +4,8 @@
 #include <assert.h>
 #include <iostream>
 
+#include "serialize-helpers.hpp"
+
 namespace lost {
 
 /// Multiply two quaternions using the usual definition of quaternion multiplication (effectively composes rotations)
@@ -446,25 +448,19 @@ bool Attitude::IsKnown() const {
     }
 }
 
-/// The length that a Vec3 will take up when serialized
-long SerializeLengthVec3() {
-    return sizeof(float)*3;
-}
-
 /// Serialize a Vec3 to buffer. Takes up space according to SerializeLengthVec3
-void SerializeVec3(const Vec3 &vec, unsigned char *buffer) {
-    float *fBuffer = (float *)buffer;
-    *fBuffer++ = vec.x;
-    *fBuffer++ = vec.y;
-    *fBuffer = vec.z;
+void SerializeVec3(std::vector<unsigned char> *buffer, const Vec3 &vec) {
+    SerializePrimitive<float>(buffer, vec.x);
+    SerializePrimitive<float>(buffer, vec.y);
+    SerializePrimitive<float>(buffer, vec.z);
 }
 
-Vec3 DeserializeVec3(const unsigned char *buffer) {
-    Vec3 result;
-    const float *fBuffer = (float *)buffer;
-    result.x = *fBuffer++;
-    result.y = *fBuffer++;
-    result.z = *fBuffer;
+Vec3 DeserializeVec3(DeserializeContext *des) {
+    Vec3 result = {
+        DeserializePrimitive<float>(des),
+        DeserializePrimitive<float>(des),
+        DeserializePrimitive<float>(des),
+    };
     return result;
 }
 

--- a/src/attitude-utils.hpp
+++ b/src/attitude-utils.hpp
@@ -2,6 +2,9 @@
 #define ATTITUDE_UTILS_H
 
 #include <memory>
+#include <vector>
+
+#include "serialize-helpers.hpp"
 
 namespace lost {
 
@@ -67,8 +70,8 @@ public:
 extern const Mat3 kIdentityMat3;
 
 long SerializeLengthVec3();
-void SerializeVec3(const Vec3 &, unsigned char *);
-Vec3 DeserializeVec3(const unsigned char *);
+void SerializeVec3(std::vector<unsigned char> *, const Vec3 &);
+Vec3 DeserializeVec3(DeserializeContext *des);
 
 float Distance(const Vec2 &, const Vec2 &);
 float Distance(const Vec3 &, const Vec3 &);

--- a/src/attitude-utils.hpp
+++ b/src/attitude-utils.hpp
@@ -69,8 +69,7 @@ public:
 
 extern const Mat3 kIdentityMat3;
 
-long SerializeLengthVec3();
-void SerializeVec3(std::vector<unsigned char> *, const Vec3 &);
+void SerializeVec3(SerializeContext *, const Vec3 &);
 Vec3 DeserializeVec3(DeserializeContext *des);
 
 float Distance(const Vec2 &, const Vec2 &);

--- a/src/database-options.hpp
+++ b/src/database-options.hpp
@@ -2,11 +2,13 @@
 
 #include <string>
 
-LOST_CLI_OPTION("min-mag"              , float      , minMag                , 100   , atof(optarg)   , kNoDefaultArgument)
-LOST_CLI_OPTION("max-stars"            , int        , maxStars              , 10000 , atoi(optarg)   , kNoDefaultArgument)
-LOST_CLI_OPTION("min-separation"       , float      , minSeparation         , 0.08  , atof(optarg)   , kNoDefaultArgument)
-LOST_CLI_OPTION("kvector"              , bool       , kvector               , false , atobool(optarg), true)
-LOST_CLI_OPTION("kvector-min-distance" , float      , kvectorMinDistance    , 0.5   , atof(optarg)   , kNoDefaultArgument)
-LOST_CLI_OPTION("kvector-max-distance" , float      , kvectorMaxDistance    , 15    , atof(optarg)   , kNoDefaultArgument)
-LOST_CLI_OPTION("kvector-distance-bins", long       , kvectorNumDistanceBins, 10000 , atol(optarg)   , kNoDefaultArgument)
-LOST_CLI_OPTION("output"               , std::string, outputPath            , "-"   , optarg         , kNoDefaultArgument)
+LOST_CLI_OPTION("min-mag"                , float      , minMag                , 100   , atof(optarg)   , kNoDefaultArgument)
+LOST_CLI_OPTION("max-stars"              , int        , maxStars              , 10000 , atoi(optarg)   , kNoDefaultArgument)
+LOST_CLI_OPTION("min-separation"         , float      , minSeparation         , 0.08  , atof(optarg)   , kNoDefaultArgument)
+LOST_CLI_OPTION("kvector"                , bool       , kvector               , false , atobool(optarg), true)
+LOST_CLI_OPTION("kvector-min-distance"   , float      , kvectorMinDistance    , 0.5   , atof(optarg)   , kNoDefaultArgument)
+LOST_CLI_OPTION("kvector-max-distance"   , float      , kvectorMaxDistance    , 15    , atof(optarg)   , kNoDefaultArgument)
+LOST_CLI_OPTION("kvector-distance-bins"  , long       , kvectorNumDistanceBins, 10000 , atol(optarg)   , kNoDefaultArgument)
+LOST_CLI_OPTION("swap-integer-endianness", bool       , swapIntegerEndianness , false , atobool(optarg), true)
+LOST_CLI_OPTION("swap-float-endianness"  , bool       , swapFloatEndianness   , false , atobool(optarg), true)
+LOST_CLI_OPTION("output"                 , std::string, outputPath            , "-"   , optarg         , kNoDefaultArgument)

--- a/src/databases.cpp
+++ b/src/databases.cpp
@@ -58,7 +58,7 @@ bool CompareKVectorPairs(const KVectorPair &p1, const KVectorPair &p2) {
  * @param buffer[out] index is written here.
  */
 void SerializeKVectorIndex(std::vector<unsigned char> *buffer, const std::vector<float> &values, float min, float max, long numBins) {
-    std::vector<int32_t> kVector(numBins+1); // numBins = length, all elements zero
+    std::vector<int32_t> kVector(numBins+1); // We store sums before and after each bin
     float binWidth = (max - min) / numBins;
 
     // generate the k-vector part
@@ -114,7 +114,7 @@ KVectorIndex::KVectorIndex(DeserializeContext *des) {
     assert(max > min);
     binWidth = (max - min) / numBins;
 
-    bins = DeserializeArray<int32_t>(des, numBins);
+    bins = DeserializeArray<int32_t>(des, numBins+1);
 }
 
 /**

--- a/src/databases.cpp
+++ b/src/databases.cpp
@@ -9,9 +9,12 @@
 #include <iostream>
 
 #include "attitude-utils.hpp"
+#include "serialize-helpers.hpp"
 #include "star-utils.hpp"
 
 namespace lost {
+
+const int32_t PairDistanceKVectorDatabase::kMagicValue = 0x2536f009;
 
 struct KVectorPair {
     int16_t index1;
@@ -38,11 +41,6 @@ bool CompareKVectorPairs(const KVectorPair &p1, const KVectorPair &p2) {
  |               |            | min+i*(max-min)/numBins                                     |
  */
 
-/// The number of bytes that a kvector index will take up whe serialized
-long SerializeLengthKVectorIndex(long numBins) {
-    return 4+sizeof(float)+sizeof(float)+4+4*(numBins+1);
-}
-
 // apparently there's no easy way to accept an iterator argument. Hate java all you want, but at
 // least it can do that!
 // https://stackoverflow.com/questions/5054087/declare-a-function-accepting-generic-iterator or
@@ -59,7 +57,7 @@ long SerializeLengthKVectorIndex(long numBins) {
  * @param numBins the number of "bins" the KVector should use. A higher number makes query results "tighter" but takes up more disk space. Usually should be set somewhat smaller than (max-min) divided by the "width" of the typical query.
  * @param buffer[out] index is written here.
  */
-void SerializeKVectorIndex(const std::vector<float> &values, float min, float max, long numBins, unsigned char *buffer) {
+void SerializeKVectorIndex(std::vector<unsigned char> *buffer, const std::vector<float> &values, float min, float max, long numBins) {
     std::vector<int32_t> kVector(numBins+1); // numBins = length, all elements zero
     float binWidth = (max - min) / numBins;
 
@@ -92,45 +90,31 @@ void SerializeKVectorIndex(const std::vector<float> &values, float min, float ma
         lastBinVal = bin;
     }
 
-    unsigned char *bufferStart = buffer;
     // metadata fields
-    *(int32_t *)buffer = values.size();
-    buffer += sizeof(int32_t);
-    *(float *)buffer = min;
-    buffer += sizeof(float);
-    *(float *)buffer = max;
-    buffer += sizeof(float);
-    *(int32_t *)buffer = numBins;
-    buffer += sizeof(int32_t);
+    SerializePrimitive<int32_t>(buffer, values.size());
+    SerializePrimitive<float>(buffer, min);
+    SerializePrimitive<float>(buffer, max);
+    SerializePrimitive<int32_t>(buffer, numBins);
 
     // kvector index field
-    // you could probably do this with memcpy instead, but the explicit loop is necessary for endian
-    // concerns? TODO endianness
     for (const int32_t &bin : kVector) {
-        *(int32_t *)buffer = bin;
-        buffer += sizeof(int32_t);
+        SerializePrimitive<int32_t>(buffer, bin);
     }
-
-    // verify length
-    assert(buffer - bufferStart == SerializeLengthKVectorIndex(numBins));
 }
 
 /// Construct from serialized buffer.
-KVectorIndex::KVectorIndex(const unsigned char *buffer) {
-    numValues = *(int32_t *)buffer;
-    buffer += sizeof(int32_t);
-    min = *(float *)buffer;
-    buffer += sizeof(float);
-    max = *(float *)buffer;
-    buffer += sizeof(float);
-    numBins = *(int32_t *)buffer;
-    buffer += sizeof(int32_t);
+KVectorIndex::KVectorIndex(DeserializeContext *des) {
+
+    numValues = DeserializePrimitive<int32_t>(des);
+    min = DeserializePrimitive<float>(des);
+    max = DeserializePrimitive<float>(des);
+    numBins = DeserializePrimitive<int32_t>(des);
 
     assert(min >= 0.0f);
     assert(max > min);
     binWidth = (max - min) / numBins;
 
-    bins = (const int32_t *)buffer;
+    bins = DeserializeArray<int32_t>(des, numBins);
 }
 
 /**
@@ -203,20 +187,11 @@ std::vector<KVectorPair> CatalogToPairDistances(const Catalog &catalog, float mi
     return result;
 }
 
-long SerializeLengthPairDistanceKVector(long numPairs, long numBins) {
-    return SerializeLengthKVectorIndex(numBins) + 2*sizeof(int16_t)*numPairs;
-}
-
-/// Number of bytes that a serialized KVectorDatabase will take up
-long SerializeLengthPairDistanceKVector(const Catalog &catalog, float minDistance, float maxDistance, long numBins) {
-    return SerializeLengthPairDistanceKVector(CatalogToPairDistances(catalog, minDistance, maxDistance).size(), numBins);
-}
-
 /**
  * Serialize a pair-distance KVector into buffer.
  * Use SerializeLengthPairDistanceKVector to determine how large the buffer needs to be. See command line documentation for other options.
  */
-void SerializePairDistanceKVector(const Catalog &catalog, float minDistance, float maxDistance, long numBins, unsigned char *buffer) {
+void SerializePairDistanceKVector(std::vector<unsigned char> *buffer, const Catalog &catalog, float minDistance, float maxDistance, long numBins) {
     std::vector<int32_t> kVector(numBins+1); // numBins = length, all elements zero
     std::vector<KVectorPair> pairs = CatalogToPairDistances(catalog, minDistance, maxDistance);
 
@@ -228,31 +203,21 @@ void SerializePairDistanceKVector(const Catalog &catalog, float minDistance, flo
         distances.push_back(pair.distance);
     }
 
-    unsigned char *bufferStart = buffer;
-
     // index field
-    SerializeKVectorIndex(distances, minDistance, maxDistance, numBins, buffer);
-    buffer += SerializeLengthKVectorIndex(numBins);
+    SerializeKVectorIndex(buffer, distances, minDistance, maxDistance, numBins);
 
     // bulk pairs field
     for (const KVectorPair &pair : pairs) {
-        *(int16_t *)buffer = pair.index1;
-        buffer += sizeof(int16_t);
-        *(int16_t *)buffer = pair.index2;
-        buffer += sizeof(int16_t);
+        SerializePrimitive<int16_t>(buffer, pair.index1);
+        SerializePrimitive<int16_t>(buffer, pair.index2);
     }
-
-    // verify length
-    assert(buffer - bufferStart == SerializeLengthPairDistanceKVector(pairs.size(), numBins));
 }
 
 /// Create the database from a serialized buffer.
-PairDistanceKVectorDatabase::PairDistanceKVectorDatabase(const unsigned char *buffer)
-    : index(KVectorIndex(buffer)) {
+PairDistanceKVectorDatabase::PairDistanceKVectorDatabase(DeserializeContext *des)
+    : index(KVectorIndex(des)) {
 
-    // TODO: errors? (not even sure what i meant by this comment anymore)
-    buffer += SerializeLengthKVectorIndex(index.NumBins());
-    pairs = (const int16_t *)buffer;
+    pairs = DeserializeArray<int16_t>(des, 2*index.NumValues());
 }
 
 /// Return the value in the range [low,high] which is closest to num
@@ -328,11 +293,13 @@ std::vector<float> PairDistanceKVectorDatabase::StarDistances(int16_t star, cons
 /**
    MultiDatabase memory layout:
 
-   | size           | name              | description                                             |
-   |----------------+-------------------+---------------------------------------------------------|
-   | 8*maxDatabases | table of contents | each 8-byte entry is the 4-byte magic value followed by |
-   |                |                   | a 4-byte index into the bulk where that db begins       |
-   | Large          | databases         | the database contents                                   |
+   | size | name           | description                                 |
+   |------+----------------+---------------------------------------------|
+   |    4 | magicValue     | unique database identifier                  |
+   |    4 | databaseLength | length in bytes (32-bit unsigned)           |
+   |    n | database       | the entire database. 8-byte aligned         |
+   |  ... | ...            | More databases (each has value, length, db) |
+   |    4 | caboose        | 4 null bytes indicate the end               |
  */
 
 /**
@@ -342,61 +309,35 @@ std::vector<float> PairDistanceKVectorDatabase::StarDistances(int16_t star, cons
  * @return Returns a pointer to the start of the database type indicated by the magic value, null if not found
  */
 const unsigned char *MultiDatabase::SubDatabasePointer(int32_t magicValue) const {
-    long databaseIndex = -1;
-    int32_t *toc = (int32_t *)buffer;
-    for (int i = 0; i < kMultiDatabaseMaxDatabases; i++) {
-        int32_t curMagicValue = *toc;
-        toc++;
+    DeserializeContext desValue(buffer);
+    DeserializeContext *des = &desValue; // just for naming consistency with how we use `des` elsewhere
+
+    assert(magicValue != 0);
+    while (true) {
+        int32_t curMagicValue = DeserializePrimitive<int32_t>(des);
+        if (curMagicValue == 0) {
+            return nullptr;
+        }
+        uint32_t dbLength = DeserializePrimitive<uint32_t>(des);
+        assert(dbLength > 0);
+        DeserializePadding<uint64_t>(des); // align to an 8-byte boundary
+        const unsigned char *curSubDatabasePointer = DeserializeArray<unsigned char>(des, dbLength);
         if (curMagicValue == magicValue) {
-            databaseIndex = *toc;
-            break;
+            return curSubDatabasePointer;
         }
-        toc++;
     }
-    // the database was not found
-    if (databaseIndex < 0) {
-        return NULL;
-    }
-
-    return buffer+kMultiDatabaseTocLength+databaseIndex;
+    // shouldn't ever make it here. Compiler should remove this assertion as unreachable.
+    assert(false);
 }
 
-/**
- * Add a database to a MultiDatabase
- * @param magicValue A value unique to this type of database which is used to extract it out of the database later.
- * @param length The number of bytes to allocate for this database.
- * @return Pointer to the start of the space allocated for said database. Return null if full (too many databases).
- */
-unsigned char *MultiDatabaseBuilder::AddSubDatabase(int32_t magicValue, long length) {
-    // find unused spot in toc and take it!
-    int32_t *toc = (int32_t *)buffer;
-    bool foundSpot = false;
-    for (int i = 0; i < kMultiDatabaseMaxDatabases; i++) {
-        if (*toc == 0) {
-            *toc = magicValue;
-            toc++;
-            *toc = bulkLength;
-            foundSpot = true;
-            break;
-        }
-        // skip the entry
-        toc += 2;
+void SerializeMultiDatabase(std::vector<unsigned char> *buffer, const MultiDatabaseDescriptor &dbs) {
+    for (const MultiDatabaseEntry &multiDbEntry : dbs) {
+        SerializePrimitive<int32_t>(buffer, multiDbEntry.magicValue);
+        SerializePrimitive<uint32_t>(buffer, multiDbEntry.bytes.size());
+        SerializePadding<uint64_t>(buffer);
+        std::copy(multiDbEntry.bytes.cbegin(), multiDbEntry.bytes.cend(), std::back_inserter(*buffer));
     }
-
-    // database is full
-    if (!foundSpot) {
-        return NULL;
-    }
-
-    buffer = (unsigned char *)realloc(buffer, kMultiDatabaseTocLength+bulkLength+length);
-    // just past the end of the last database
-    unsigned char *result = buffer+kMultiDatabaseTocLength+bulkLength;
-    bulkLength += length;
-    return result;
-}
-
-MultiDatabaseBuilder::~MultiDatabaseBuilder() {
-    free(buffer);
+    SerializePrimitive<int32_t>(buffer, 0); // caboose
 }
 
 }

--- a/src/databases.hpp
+++ b/src/databases.hpp
@@ -42,7 +42,7 @@ private:
     const int32_t *bins;
 };
 
-void SerializePairDistanceKVector(std::vector<unsigned char> *buffer, const Catalog &, float minDistance, float maxDistance, long numBins);
+void SerializePairDistanceKVector(SerializeContext *, const Catalog &, float minDistance, float maxDistance, long numBins);
 
 /**
  * A database storing distances between pairs of stars.
@@ -116,7 +116,7 @@ public:
 
 typedef std::vector<MultiDatabaseEntry> MultiDatabaseDescriptor;
 
-void SerializeMultiDatabase(std::vector<unsigned char> *buffer, const MultiDatabaseDescriptor &dbs);
+void SerializeMultiDatabase(SerializeContext *, const MultiDatabaseDescriptor &dbs);
 
 }
 

--- a/src/databases.hpp
+++ b/src/databases.hpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "star-utils.hpp"
+#include "serialize-helpers.hpp"
 
 namespace lost {
 
@@ -19,7 +20,7 @@ const int32_t kCatalogMagicValue = 0xF9A283BC;
 // TODO: QueryConservative, QueryExact, QueryTrapezoidal?
 class KVectorIndex {
 public:
-    explicit KVectorIndex(const unsigned char *);
+    explicit KVectorIndex(DeserializeContext *des);
 
     long QueryLiberal(float minQueryDistance, float maxQueryDistance, long *upperIndex) const;
 
@@ -41,8 +42,7 @@ private:
     const int32_t *bins;
 };
 
-long SerializeLengthPairDistanceKVector(const Catalog &, float minDistance, float maxDistance, long numBins);
-void SerializePairDistanceKVector(const Catalog &, float minDistance, float maxDistance, long numBins, unsigned char *buffer);
+void SerializePairDistanceKVector(std::vector<unsigned char> *buffer, const Catalog &, float minDistance, float maxDistance, long numBins);
 
 /**
  * A database storing distances between pairs of stars.
@@ -51,7 +51,7 @@ void SerializePairDistanceKVector(const Catalog &, float minDistance, float maxD
  */
 class PairDistanceKVectorDatabase {
 public:
-    explicit PairDistanceKVectorDatabase(const unsigned char *databaseBytes);
+    explicit PairDistanceKVectorDatabase(DeserializeContext *des);
 
     const int16_t *FindPairsLiberal(float min, float max, const int16_t **end) const;
     const int16_t *FindPairsExact(const Catalog &, float min, float max, const int16_t **end) const;
@@ -65,7 +65,9 @@ public:
     long NumPairs() const;
 
     /// Magic value to use when storing inside a MultiDatabase
-    static const int32_t kMagicValue = 0x2536f009;
+    static const int32_t kMagicValue; // 0x2536f009
+    // apparently you're supposed to not actually put the value of the static variables here, but
+    // rather in a cpp implementation file.
 private:
     KVectorIndex index;
     // TODO: endianness
@@ -89,11 +91,6 @@ private:
 //     int16_t *triples;
 // };
 
-/// maximum number of databases in a MultiDatabase
-const int kMultiDatabaseMaxDatabases = 64;
-/// The size of the table of contents in a multidatabase (stores subdatabase locations)
-const long kMultiDatabaseTocLength = 8*kMultiDatabaseMaxDatabases;
-
 /**
  * A database that contains multiple databases
  * This is almost always the database that is actually passed to star-id algorithms in the real world, since you'll want to store at least the catalog plus one specific database.
@@ -108,26 +105,18 @@ private:
     const unsigned char *buffer;
 };
 
-/// Class for easily creating a MultiDatabase
-class MultiDatabaseBuilder {
+class MultiDatabaseEntry {
 public:
-    MultiDatabaseBuilder()
-        : buffer((unsigned char *)calloc(1, kMultiDatabaseTocLength)), bulkLength(0) { };
-    ~MultiDatabaseBuilder();
+    MultiDatabaseEntry(int32_t magicValue, std::vector<unsigned char> bytes) // I wonder if making `bytes` a reference would avoid making two copies, or maybe it would be worse by preventing copy-elision
+        : magicValue(magicValue), bytes(bytes) { }
 
-    unsigned char *AddSubDatabase(int32_t magicValue, long length);
-
-    /// When done adding databases, use this to get the buffer you should write to disk.
-    unsigned char *Buffer() { return buffer; };
-    /// The length of the buffer returned by Buffer
-    long BufferLength() { return kMultiDatabaseTocLength+bulkLength; };
-private:
-    // Throughout LOST, most dynamic memory is managed with `new` and `delete` to make it easier to
-    // use unique pointers. Here, however, we use realloc, so C-style memory management.
-    unsigned char *buffer;
-    // how many bytes are presently allocated for databases (excluding map)
-    long bulkLength;
+    int32_t magicValue;
+    std::vector<unsigned char> bytes;
 };
+
+typedef std::vector<MultiDatabaseEntry> MultiDatabaseDescriptor;
+
+void SerializeMultiDatabase(std::vector<unsigned char> *buffer, const MultiDatabaseDescriptor &dbs);
 
 }
 

--- a/src/io.cpp
+++ b/src/io.cpp
@@ -265,33 +265,28 @@ typedef StarIdAlgorithm *(*StarIdAlgorithmFactory)();
 
 typedef AttitudeEstimationAlgorithm *(*AttitudeEstimationAlgorithmFactory)();
 
-/// Add a pair-distance KVector database to the given builder.
-void BuildPairDistanceKVectorDatabase(MultiDatabaseBuilder *builder, const Catalog &catalog, float minDistance, float maxDistance, long numBins) {
-    // TODO: calculating the length of the vector duplicates a lot of the work, slowing down
-    // database generation
-    long length = SerializeLengthPairDistanceKVector(catalog, minDistance, maxDistance, numBins);
-    unsigned char *buffer = builder->AddSubDatabase(PairDistanceKVectorDatabase::kMagicValue, length);
-    if (buffer == NULL) {
-        std::cerr << "No room for another database." << std::endl;
-    }
-    SerializePairDistanceKVector(catalog, minDistance, maxDistance, numBins, buffer);
+MultiDatabaseDescriptor GenerateDatabases(const Catalog &catalog, const DatabaseOptions &values) {
+    MultiDatabaseDescriptor dbEntries;
 
-    // TODO: also parse it and print out some stats before returning
-}
-
-/// Generate and add databases to the given multidatabase builder according to the command line options in `values`
-void GenerateDatabases(MultiDatabaseBuilder *builder, const Catalog &catalog, const DatabaseOptions &values) {
+    // always include the serialized catalog
+    std::vector<unsigned char> catalogBuffer;
+    // TODO decide why we have this inclMagnitude and inclName and if we should change that
+    SerializeCatalog(&catalogBuffer, catalog, false, true);
+    dbEntries.emplace_back(kCatalogMagicValue, catalogBuffer);
 
     if (values.kvector) {
         float minDistance = DegToRad(values.kvectorMinDistance);
         float maxDistance = DegToRad(values.kvectorMaxDistance);
         long numBins = values.kvectorNumDistanceBins;
-        BuildPairDistanceKVectorDatabase(builder, catalog, minDistance, maxDistance, numBins);
+        std::vector<unsigned char> buffer;
+        SerializePairDistanceKVector(&buffer, catalog, minDistance, maxDistance, numBins);
+        dbEntries.emplace_back(PairDistanceKVectorDatabase::kMagicValue, buffer);
     } else {
         std::cerr << "No database builder selected -- no database generated." << std::endl;
         exit(1);
     }
 
+    return dbEntries;
 }
 
 /// Print information about the camera in machine and human-readable form.
@@ -915,7 +910,8 @@ PipelineOutput Pipeline::Go(const PipelineInput &input) {
         MultiDatabase multiDatabase(database.get());
         const unsigned char *catalogBuffer = multiDatabase.SubDatabasePointer(kCatalogMagicValue);
         if (catalogBuffer != NULL) {
-            result.catalog = DeserializeCatalog(multiDatabase.SubDatabasePointer(kCatalogMagicValue), NULL, NULL);
+            DeserializeContext des(catalogBuffer);
+            result.catalog = DeserializeCatalog(&des, NULL, NULL);
         } else {
             std::cerr << "WARNING: That database does not include a catalog. Proceeding with the full catalog." << std::endl;
             result.catalog = input.GetCatalog();

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -290,6 +290,8 @@ public:
 #undef LOST_CLI_OPTION
 };
 
+SerializeContext serFromDbValues(const DatabaseOptions &values);
+
 /// Appropriately create descriptors for all requested databases according to command-line options.
 /// @sa SerializeMultiDatabase
 MultiDatabaseDescriptor GenerateDatabases(const Catalog &, const DatabaseOptions &values);

--- a/src/io.hpp
+++ b/src/io.hpp
@@ -290,10 +290,9 @@ public:
 #undef LOST_CLI_OPTION
 };
 
-// unlike the other algorithm prompters, db builders aren't a
-// typedef void (*DbBuilder)(MultiDatabaseBuilder &, const Catalog &);
-void GenerateDatabases(MultiDatabaseBuilder *, const Catalog &, const DatabaseOptions &values);
-// void PromptDatabases(MultiDatabaseBuilder &, const Catalog &);
+/// Appropriately create descriptors for all requested databases according to command-line options.
+/// @sa SerializeMultiDatabase
+MultiDatabaseDescriptor GenerateDatabases(const Catalog &, const DatabaseOptions &values);
 
 /////////////////////
 // INSPECT CATALOG //

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,19 +28,14 @@ static void DatabaseBuild(const DatabaseOptions &values) {
     Catalog narrowedCatalog = NarrowCatalog(CatalogRead(), (int) (values.minMag * 100), values.maxStars, DegToRad(values.minSeparation));
     std::cerr << "Narrowed catalog has " << narrowedCatalog.size() << " stars." << std::endl;
 
-    MultiDatabaseBuilder builder;
-    // TODO: allow magnitude and weird
-    unsigned char
-        *catalogBuffer =
-        builder.AddSubDatabase(kCatalogMagicValue, SerializeLengthCatalog(narrowedCatalog, false, true));
-    SerializeCatalog(narrowedCatalog, false, true, catalogBuffer);
+    MultiDatabaseDescriptor dbEntries = GenerateDatabases(narrowedCatalog, values);
+    std::vector<unsigned char> buffer;
+    SerializeMultiDatabase(&buffer, dbEntries);
 
-    GenerateDatabases(&builder, narrowedCatalog, values);
-
-    std::cerr << "Generated database with " << builder.BufferLength() << " bytes" << std::endl;
+    std::cerr << "Generated database with " << buffer.size() << " bytes" << std::endl;
 
     UserSpecifiedOutputStream pos = UserSpecifiedOutputStream(values.outputPath, true);
-    pos.Stream().write((char *) builder.Buffer(), builder.BufferLength());
+    pos.Stream().write((char *) buffer.data(), buffer.size());
 
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,13 +29,13 @@ static void DatabaseBuild(const DatabaseOptions &values) {
     std::cerr << "Narrowed catalog has " << narrowedCatalog.size() << " stars." << std::endl;
 
     MultiDatabaseDescriptor dbEntries = GenerateDatabases(narrowedCatalog, values);
-    std::vector<unsigned char> buffer;
-    SerializeMultiDatabase(&buffer, dbEntries);
+    SerializeContext ser = serFromDbValues(values);
+    SerializeMultiDatabase(&ser, dbEntries);
 
-    std::cerr << "Generated database with " << buffer.size() << " bytes" << std::endl;
+    std::cerr << "Generated database with " << ser.buffer.size() << " bytes" << std::endl;
 
     UserSpecifiedOutputStream pos = UserSpecifiedOutputStream(values.outputPath, true);
-    pos.Stream().write((char *) buffer.data(), buffer.size());
+    pos.Stream().write((char *) ser.buffer.data(), ser.buffer.size());
 
 }
 

--- a/src/serialize-helpers.hpp
+++ b/src/serialize-helpers.hpp
@@ -1,0 +1,146 @@
+/**
+ * Helpers to serialize and deserialize arbitrary data types to disk
+ *
+ * The serialization and deserialization helpers here assume that (a) integers and floating point
+ * numbers are stored in the same format on the source and target systems except for endianness, and
+ * (b) the target system requires no greater than n-byte alignment for n-byte values (eg, an int32_t
+ * only needs 4-byte alignment, not 8-byte), and (c) the database itself will be aligned at a
+ * multiple of the largest size of any value stored within (because we only align values relative to
+ * the start of the database, so everything breaks if the database itself is misaligned).
+ *
+ * Generally, the "bulk" of any database will not be explicitly deserialized into a data structure
+ * in memory, but instead will just effectively memory-mapped, by just storing a pointer to a
+ * certain offset into the database. The serialization functions in this file can still be used to
+ * create such a "bulk" section, but deserialization must be handled manually.
+ */
+
+#ifndef SERIALIZE_HELPERS_H
+#define SERIALIZE_HELPERS_H
+
+#include <utility>
+#include <vector>
+#include <string.h>
+
+#ifndef LOST_DATABASE_SOURCE_INTEGER_ENDIANNESS
+#define LOST_DATABASE_SOURCE_INTEGER_ENDIANNESS lost::Endianness::LittleEndian
+#endif
+
+#ifndef LOST_DATABASE_SOURCE_FLOAT_ENDIANNESS
+#define LOST_DATABASE_SOURCE_FLOAT_ENDIANNESS lost::Endianness::LittleEndian
+#endif
+
+#ifndef LOST_DATABASE_TARGET_INTEGER_ENDIANNESS
+#define LOST_DATABASE_TARGET_INTEGER_ENDIANNESS lost::Endianness::LittleEndian
+#endif
+
+#ifndef LOST_DATABASE_TARGET_FLOAT_ENDIANNESS
+#define LOST_DATABASE_TARGET_FLOAT_ENDIANNESS lost::Endianness::LittleEndian
+#endif
+
+namespace lost {
+
+enum class Endianness {
+    LittleEndian,
+    BigEndian,
+};
+
+class DeserializeContext {
+public:
+    DeserializeContext(const unsigned char *buffer) : buffer(buffer), cursor(buffer) { };
+
+    size_t GetOffset() const {
+        return cursor - buffer;
+    }
+
+    void MoveForward(size_t howMuch) {
+        cursor += howMuch;
+    }
+
+    const unsigned char *GetCursor() {
+        return cursor;
+    }
+
+private:
+    const unsigned char *buffer; /// the start of the buffer
+    const unsigned char *cursor; /// the current location of the "read head" into the buffer
+};
+
+/// Unconditionally swap the endianness of a value (uses sizeof T).
+template <typename T>
+void SwapEndianness(T *buffer) {
+    char *charBuffer = (char *)buffer;
+    for (int i = 0; i < (int)(sizeof(T)/2); i++) {
+        std::swap(charBuffer[i], charBuffer[sizeof(T)-1-i]);
+    }
+}
+
+/// Swap the endianness of a value if necessary. Uses
+/// LOST_DATABASE_{SOURCE,TARGET}_INTEGER_ENDIANNESS to determine to switch all values but float and
+/// double, which use LOST_DATABASE_{SOURCE,TARGET}_FLOAT_ENDIANNESS.
+template <typename T>
+void SwapEndiannessIfNecessary(T *buffer) {
+    if (LOST_DATABASE_SOURCE_INTEGER_ENDIANNESS != LOST_DATABASE_TARGET_INTEGER_ENDIANNESS) {
+        SwapEndianness<T>(buffer);
+    }
+}
+
+// template specializations
+
+template <>
+inline void SwapEndiannessIfNecessary<float>(float *buffer) {
+    if (LOST_DATABASE_SOURCE_FLOAT_ENDIANNESS != LOST_DATABASE_TARGET_FLOAT_ENDIANNESS) {
+        SwapEndianness<float>(buffer);
+    }
+}
+
+template <>
+inline void SwapEndiannessIfNecessary<double>(double *buffer) {
+    if (LOST_DATABASE_SOURCE_FLOAT_ENDIANNESS != LOST_DATABASE_TARGET_FLOAT_ENDIANNESS) {
+        SwapEndianness<double>(buffer);
+    }
+}
+
+/// Move the cursor forward past any padding that would appear before a value of type T
+template <typename T>
+void DeserializePadding(DeserializeContext *des) {
+    des->MoveForward((sizeof(T) - des->GetOffset()%sizeof(T))%sizeof(T));
+}
+
+template <typename T>
+T DeserializePrimitive(DeserializeContext *des) {
+    DeserializePadding<T>(des);
+    const T *result = (T *)des->GetCursor(); // endianness should have been taken care of during serialization
+    des->MoveForward(sizeof(T));
+    return *result;
+}
+
+/// return an array of items as a pointer. Will point into the buffer (mmap style).
+template <typename T>
+const T *DeserializeArray(DeserializeContext *des, long arrLength) {
+    DeserializePadding<T>(des); // Perhaps we should always 8-align arrays? Does that possibly make
+                                // any offset calculation or accesses faster?
+    const T *result = (T *)des->GetCursor();
+    des->MoveForward(sizeof(T)*arrLength);
+    return result;
+}
+
+template <typename T>
+void SerializePadding(std::vector<unsigned char> *vec) {
+    for (int i = vec->size(); i%sizeof(T) != 0; i++) {
+        vec->push_back(0);
+    }
+}
+
+template <typename T>
+void SerializePrimitive(std::vector<unsigned char> *vec, const T &val) {
+    T tBuf;
+    memcpy(&tBuf, &val, sizeof(T));
+    SwapEndiannessIfNecessary<T>(&tBuf);
+    unsigned char *buf = (unsigned char *)(&tBuf);
+    SerializePadding<T>(vec);
+    std::copy(buf, buf+sizeof(T), std::back_inserter(*vec));
+}
+
+}
+
+#endif

--- a/src/star-id.cpp
+++ b/src/star-id.cpp
@@ -35,7 +35,8 @@ StarIdentifiers GeometricVotingStarIdAlgorithm::Go(
     if (databaseBuffer == NULL) {
         return identified;
     }
-    PairDistanceKVectorDatabase vectorDatabase(databaseBuffer);
+    DeserializeContext des(databaseBuffer);
+    PairDistanceKVectorDatabase vectorDatabase(&des);
 
     for (int i = 0; i < (int)stars.size(); i++) {
         std::vector<int16_t> votes(catalog.size(), 0);
@@ -577,7 +578,8 @@ StarIdentifiers PyramidStarIdAlgorithm::Go(
         std::cerr << "Not enough stars, or database missing." << std::endl;
         return identified;
     }
-    PairDistanceKVectorDatabase vectorDatabase(databaseBuffer);
+    DeserializeContext des(databaseBuffer);
+    PairDistanceKVectorDatabase vectorDatabase(&des);
 
     // smallest normal single-precision float is around 10^-38 so we should be all good. See
     // Analytic_Star_Pattern_Probability on the HSL wiki for details.

--- a/src/star-utils.cpp
+++ b/src/star-utils.cpp
@@ -67,14 +67,14 @@ Catalog::const_iterator FindNamedStar(const Catalog &catalog, int name) {
  * @param inclName Whether to include the (numerical) name of the star.
  * @param buffer[out] Where the serialized star is stored.
  */
-void SerializeCatalogStar(std::vector<unsigned char> *buffer, const CatalogStar &catalogStar, bool inclMagnitude, bool inclName) {
-    SerializeVec3(buffer, catalogStar.spatial);
+void SerializeCatalogStar(SerializeContext *ser, const CatalogStar &catalogStar, bool inclMagnitude, bool inclName) {
+    SerializeVec3(ser, catalogStar.spatial);
     if (inclMagnitude) {
-        SerializePrimitive<float>(buffer, catalogStar.magnitude);
+        SerializePrimitive<float>(ser, catalogStar.magnitude);
     }
     if (inclName) {
         // TODO: double check that bools aren't some special bitwise thing in C++
-        SerializePrimitive<int16_t>(buffer, catalogStar.name);
+        SerializePrimitive<int16_t>(ser, catalogStar.name);
     }
 }
 
@@ -104,15 +104,15 @@ CatalogStar DeserializeCatalogStar(DeserializeContext *des, bool inclMagnitude, 
  * Use SerializeLengthCatalog() to determine how many bytes to allocate in `buffer`
  * @param inclMagnitude,inclName See SerializeCatalogStar()
  */
-void SerializeCatalog(std::vector<unsigned char> *buffer, const Catalog &catalog, bool inclMagnitude, bool inclName) {
-    SerializePrimitive<int16_t>(buffer, catalog.size());
+void SerializeCatalog(SerializeContext *ser, const Catalog &catalog, bool inclMagnitude, bool inclName) {
+    SerializePrimitive<int16_t>(ser, catalog.size());
 
     // flags
     int8_t flags = (inclMagnitude) | (inclName << 1);
-    SerializePrimitive<int8_t>(buffer, flags);
+    SerializePrimitive<int8_t>(ser, flags);
 
     for (const CatalogStar &catalogStar : catalog) {
-        SerializeCatalogStar(buffer, catalogStar, inclMagnitude, inclName);
+        SerializeCatalogStar(ser, catalogStar, inclMagnitude, inclName);
     }
 }
 

--- a/src/star-utils.cpp
+++ b/src/star-utils.cpp
@@ -5,6 +5,8 @@
 #include <algorithm>
 #include <set>
 
+#include "serialize-helpers.hpp"
+
 namespace lost {
 
 // brightest star first
@@ -58,18 +60,6 @@ Catalog::const_iterator FindNamedStar(const Catalog &catalog, int name) {
     return catalog.cend();
 }
 
-/// @sa SerializeCatalogStar
-long SerializeLengthCatalogStar(bool inclMagnitude, bool inclName) {
-    long starSize = SerializeLengthVec3();
-    if (inclMagnitude) {
-        starSize += sizeof(float);
-    }
-    if (inclName) {
-        starSize += sizeof(int16_t);
-    }
-    return starSize;
-}
-
 /**
  * Serialize a CatalogStar into a byte buffer.
  * Use SerializeLengthCatalogStar() to determine how many bytes to allocate in `buffer`
@@ -77,17 +67,14 @@ long SerializeLengthCatalogStar(bool inclMagnitude, bool inclName) {
  * @param inclName Whether to include the (numerical) name of the star.
  * @param buffer[out] Where the serialized star is stored.
  */
-void SerializeCatalogStar(const CatalogStar &catalogStar, bool inclMagnitude, bool inclName, unsigned char *buffer) {
-    SerializeVec3(catalogStar.spatial, buffer);
-    buffer += SerializeLengthVec3();
+void SerializeCatalogStar(std::vector<unsigned char> *buffer, const CatalogStar &catalogStar, bool inclMagnitude, bool inclName) {
+    SerializeVec3(buffer, catalogStar.spatial);
     if (inclMagnitude) {
-        *(float *)buffer = catalogStar.magnitude;
-        buffer += sizeof(float);
+        SerializePrimitive<float>(buffer, catalogStar.magnitude);
     }
     if (inclName) {
         // TODO: double check that bools aren't some special bitwise thing in C++
-        *(int16_t *)buffer = catalogStar.name;
-        buffer += sizeof(int16_t);
+        SerializePrimitive<int16_t>(buffer, catalogStar.name);
     }
 }
 
@@ -96,28 +83,20 @@ void SerializeCatalogStar(const CatalogStar &catalogStar, bool inclMagnitude, bo
  * @warn The `inclMagnitude` and `inclName` parameters must be the same as passed to SerializeCatalogStar()
  * @sa SerializeCatalogStar
  */
-CatalogStar DeserializeCatalogStar(const unsigned char *buffer, bool inclMagnitude, bool inclName) {
+CatalogStar DeserializeCatalogStar(DeserializeContext *des, bool inclMagnitude, bool inclName) {
     CatalogStar result;
-    result.spatial = DeserializeVec3(buffer);
-    buffer += SerializeLengthVec3();
+    result.spatial = DeserializeVec3(des);
     if (inclMagnitude) {
-        result.magnitude = *(float *)buffer;
-        buffer += sizeof(float);
+        result.magnitude = DeserializePrimitive<float>(des);
     } else {
         result.magnitude = -424242; // TODO, what to do about special values, since there's no good ones for ints.
     }
     if (inclName) {
-        result.name = *(int16_t *)buffer;
-        buffer += sizeof(int16_t);
+        result.name = DeserializePrimitive<int16_t>(des);
     } else {
         result.name = -1;
     }
     return result;
-}
-
-/// @sa SerializeCatalog
-long SerializeLengthCatalog(const Catalog &catalog, bool inclMagnitude, bool inclName) {
-    return sizeof(int16_t) + sizeof(int8_t) + catalog.size()*SerializeLengthCatalogStar(inclMagnitude, inclName);
 }
 
 /**
@@ -125,56 +104,41 @@ long SerializeLengthCatalog(const Catalog &catalog, bool inclMagnitude, bool inc
  * Use SerializeLengthCatalog() to determine how many bytes to allocate in `buffer`
  * @param inclMagnitude,inclName See SerializeCatalogStar()
  */
-void SerializeCatalog(const Catalog &catalog, bool inclMagnitude, bool inclName, unsigned char *buffer) {
-    unsigned char *bufferStart = buffer;
-
-    // size
-    *(int16_t *)buffer = catalog.size();
-    buffer += sizeof(int16_t);
+void SerializeCatalog(std::vector<unsigned char> *buffer, const Catalog &catalog, bool inclMagnitude, bool inclName) {
+    SerializePrimitive<int16_t>(buffer, catalog.size());
 
     // flags
     int8_t flags = (inclMagnitude) | (inclName << 1);
-    *(int8_t *)buffer = flags;
-    buffer += sizeof(int8_t);
+    SerializePrimitive<int8_t>(buffer, flags);
 
-    long catalogStarLength = SerializeLengthCatalogStar(inclMagnitude, inclName);
     for (const CatalogStar &catalogStar : catalog) {
-        SerializeCatalogStar(catalogStar, inclMagnitude, inclName, buffer);
-        buffer += catalogStarLength;
+        SerializeCatalogStar(buffer, catalogStar, inclMagnitude, inclName);
     }
-
-    assert(buffer-bufferStart == SerializeLengthCatalog(catalog, inclMagnitude, inclName));
 }
-
-// TODO (longer term): don't deserialize the catalog, store it on disk using the in-memory format so
-// we can just copy it to memory then cast
 
 /**
  * Deserialize a catalog.
  * @param[out] inclMagnitudeReturn,inclNameReturn Will store whether `inclMagnitude` and `inclNameReturn` were set in the corresponding SerializeCatalog() call.
  */
-Catalog DeserializeCatalog(const unsigned char *buffer, bool *inclMagnitudeReturn, bool *inclNameReturn) {
+Catalog DeserializeCatalog(DeserializeContext *des, bool *inclMagnitudeReturn, bool *inclNameReturn) {
     bool inclName, inclMagnitude;
     Catalog result;
 
-    int16_t numStars = *(int16_t *)buffer;
-    buffer += sizeof(int16_t);
+    int16_t numStars = DeserializePrimitive<int16_t>(des);
 
-    int8_t flags = *(int8_t *)buffer;
+    int8_t flags = DeserializePrimitive<int8_t>(des);
     inclMagnitude = (flags) & 1;
     inclName = (flags>>1) & 1;
+
     if (inclMagnitudeReturn != NULL) {
         *inclMagnitudeReturn = inclMagnitude;
     }
     if (inclNameReturn != NULL) {
         *inclNameReturn = inclName;
     }
-    buffer += sizeof(int8_t);
 
-    int catalogStarLength = SerializeLengthCatalogStar(inclMagnitude, inclName);
     for (int i = 0; i < numStars; i++) {
-        result.push_back(DeserializeCatalogStar(buffer, inclMagnitude, inclName));
-        buffer += catalogStarLength;
+        result.push_back(DeserializeCatalogStar(des, inclMagnitude, inclName));
     }
 
     return result;

--- a/src/star-utils.hpp
+++ b/src/star-utils.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "attitude-utils.hpp"
+#include "serialize-helpers.hpp"
 
 namespace lost {
 
@@ -100,10 +101,9 @@ typedef std::vector<CatalogStar> Catalog;
 typedef std::vector<Star> Stars;
 typedef std::vector<StarIdentifier> StarIdentifiers;
 
-long SerializeLengthCatalog(const Catalog &, bool inclMagnitude, bool inclName);
-void SerializeCatalog(const Catalog &, bool inclMagnitude, bool inclName, unsigned char *buffer);
+void SerializeCatalog(std::vector<unsigned char> *buffer, const Catalog &, bool inclMagnitude, bool inclName);
 // sets magnited and name to whether the catalog in the database contained magnitude and name
-Catalog DeserializeCatalog(const unsigned char *buffer, bool *inclMagnitudeReturn, bool *inclNameReturn);
+Catalog DeserializeCatalog(DeserializeContext *des, bool *inclMagnitudeReturn, bool *inclNameReturn);
 Catalog::const_iterator FindNamedStar(const Catalog &catalog, int name);
 
 /// returns some relative brightness measure, which is proportional to the total number of photons received from a star.

--- a/src/star-utils.hpp
+++ b/src/star-utils.hpp
@@ -101,7 +101,7 @@ typedef std::vector<CatalogStar> Catalog;
 typedef std::vector<Star> Stars;
 typedef std::vector<StarIdentifier> StarIdentifiers;
 
-void SerializeCatalog(std::vector<unsigned char> *buffer, const Catalog &, bool inclMagnitude, bool inclName);
+void SerializeCatalog(SerializeContext *, const Catalog &, bool inclMagnitude, bool inclName);
 // sets magnited and name to whether the catalog in the database contained magnitude and name
 Catalog DeserializeCatalog(DeserializeContext *des, bool *inclMagnitudeReturn, bool *inclNameReturn);
 Catalog::const_iterator FindNamedStar(const Catalog &catalog, int name);

--- a/test/identify-remaining-stars.cpp
+++ b/test/identify-remaining-stars.cpp
@@ -52,9 +52,9 @@ TEST_CASE("IRUnidentifiedCentroid obtuse angle", "[identify-remaining] [fast]") 
 
 std::vector<int16_t> IdentifyThirdStarTest(const Catalog &catalog, int16_t catalogName1, int16_t catalogName2,
                                            float dist1, float dist2, float tolerance) {
-    std::vector<unsigned char> dbBytes;
-    SerializePairDistanceKVector(&dbBytes, integralCatalog, 0, M_PI, 1000);
-    DeserializeContext des(dbBytes.data());
+    SerializeContext ser;
+    SerializePairDistanceKVector(&ser, integralCatalog, 0, M_PI, 1000);
+    DeserializeContext des(ser.buffer.data());
     auto cs1 = FindNamedStar(catalog, catalogName1);
     auto cs2 = FindNamedStar(catalog, catalogName2);
 
@@ -165,9 +165,9 @@ TEST_CASE("IdentifyRemainingStars fuzz", "[identify-remaining] [fuzz]") {
         someFakeStarIds.push_back(fakeStarIdsCopy[i]);
     }
 
-    std::vector<unsigned char> dbBytes;
-    SerializePairDistanceKVector(&dbBytes, fakeCatalog, 0, M_PI, 1000);
-    DeserializeContext des(dbBytes.data());
+    SerializeContext ser;
+    SerializePairDistanceKVector(&ser, fakeCatalog, 0, M_PI, 1000);
+    DeserializeContext des(ser.buffer.data());
     PairDistanceKVectorDatabase db(&des);
 
     int numIdentified = IdentifyRemainingStarsPairDistance(&someFakeStarIds, fakeCentroids, db, fakeCatalog, smolCamera, 1e-5);

--- a/test/identify-remaining-stars.cpp
+++ b/test/identify-remaining-stars.cpp
@@ -2,6 +2,7 @@
 
 #include <catch.hpp>
 
+#include "databases.hpp"
 #include "star-id.hpp"
 #include "star-id-private.hpp"
 
@@ -51,16 +52,17 @@ TEST_CASE("IRUnidentifiedCentroid obtuse angle", "[identify-remaining] [fast]") 
 
 std::vector<int16_t> IdentifyThirdStarTest(const Catalog &catalog, int16_t catalogName1, int16_t catalogName2,
                                            float dist1, float dist2, float tolerance) {
-    unsigned char *dbBytes = BuildPairDistanceKVectorDatabase(integralCatalog, NULL, 0, M_PI, 1000);
+    std::vector<unsigned char> dbBytes;
+    SerializePairDistanceKVector(&dbBytes, integralCatalog, 0, M_PI, 1000);
+    DeserializeContext des(dbBytes.data());
     auto cs1 = FindNamedStar(catalog, catalogName1);
     auto cs2 = FindNamedStar(catalog, catalogName2);
 
-    PairDistanceKVectorDatabase db(dbBytes);
+    PairDistanceKVectorDatabase db(&des);
     auto result = IdentifyThirdStar(db,
                                     catalog,
                                     cs1 - catalog.cbegin(), cs2 - catalog.cbegin(),
                                     dist1, dist2, tolerance);
-    delete[] dbBytes;
     return result;
 }
 
@@ -163,12 +165,12 @@ TEST_CASE("IdentifyRemainingStars fuzz", "[identify-remaining] [fuzz]") {
         someFakeStarIds.push_back(fakeStarIdsCopy[i]);
     }
 
-    unsigned char *dbBytes = BuildPairDistanceKVectorDatabase(fakeCatalog, NULL, 0, M_PI, 1000);
-    PairDistanceKVectorDatabase db(dbBytes);
+    std::vector<unsigned char> dbBytes;
+    SerializePairDistanceKVector(&dbBytes, fakeCatalog, 0, M_PI, 1000);
+    DeserializeContext des(dbBytes.data());
+    PairDistanceKVectorDatabase db(&des);
 
     int numIdentified = IdentifyRemainingStarsPairDistance(&someFakeStarIds, fakeCentroids, db, fakeCatalog, smolCamera, 1e-5);
-
-    delete[] dbBytes;
 
     REQUIRE(numIdentified == numFakeStars - fakePatternSize);
     REQUIRE(AreStarIdentifiersEquivalent(fakeStarIds, someFakeStarIds));

--- a/test/kvector.cpp
+++ b/test/kvector.cpp
@@ -12,8 +12,9 @@ using namespace lost; // NOLINT
 TEST_CASE("Kvector full database stuff", "[kvector]") {
     const Catalog &catalog = CatalogRead();
     std::vector<unsigned char> dbBytes;
-    SerializePairDistanceKVector(&dbBytes, catalog, DegToRad(1.0), DegToRad(2.0), 100);
-    DeserializeContext des(dbBytes.data());
+    SerializeContext ser;
+    SerializePairDistanceKVector(&ser, catalog, DegToRad(1.0), DegToRad(2.0), 100);
+    DeserializeContext des(ser.buffer.data());
     PairDistanceKVectorDatabase db(&des);
 
     SECTION("basic consistency checks") {
@@ -52,9 +53,9 @@ TEST_CASE("Kvector full database stuff", "[kvector]") {
 
 TEST_CASE("Tighter tolerance test", "[kvector]") {
     const Catalog &catalog = CatalogRead();
-    std::vector<unsigned char> dbBytes;
-    SerializePairDistanceKVector(&dbBytes, catalog, DegToRad(0.5), DegToRad(5.0), 1000);
-    DeserializeContext des(dbBytes.data());
+    SerializeContext ser;
+    SerializePairDistanceKVector(&ser, catalog, DegToRad(0.5), DegToRad(5.0), 1000);
+    DeserializeContext des(ser.buffer.data());
     PairDistanceKVectorDatabase db(&des);
     // radius we'll request
     float delta = 0.0001;
@@ -106,9 +107,9 @@ TEST_CASE("3-star database, check exact results", "[kvector] [fast]") {
         CatalogStar(DegToRad(4), DegToRad(7), 2.0, 43),
         CatalogStar(DegToRad(2), DegToRad(6), 4.0, 44),
     };
-    std::vector<unsigned char> dbBytes;
-    SerializePairDistanceKVector(&dbBytes, tripleCatalog, DegToRad(0.5), DegToRad(20.0), 1000);
-    DeserializeContext des(dbBytes.data());
+    SerializeContext ser;
+    SerializePairDistanceKVector(&ser, tripleCatalog, DegToRad(0.5), DegToRad(20.0), 1000);
+    DeserializeContext des(ser.buffer.data());
     PairDistanceKVectorDatabase db(&des);
     REQUIRE(db.NumPairs() == 3);
 

--- a/test/serialize.cpp
+++ b/test/serialize.cpp
@@ -1,0 +1,64 @@
+// Tests for serialization and multidatabases
+
+#include <catch.hpp>
+
+#include <vector>
+
+#include "serialize-helpers.hpp"
+
+using namespace lost; // NOLINT
+
+TEST_CASE("Simple serialization, deserialization of primitives", "[fast] [serialize]") {
+    int64_t val64 = 27837492938;
+    float valFloat = 23.71728;
+    SerializeContext ser;
+    SerializePrimitive<int64_t>(&ser, val64);
+    SerializePrimitive<float>(&ser, valFloat);
+    DeserializeContext des(ser.buffer.data());
+    int64_t deserializedVal64 = DeserializePrimitive<int64_t>(&des);
+    float deserializedFloat = DeserializePrimitive<float>(&des);
+    CHECK(val64 == deserializedVal64);
+    CHECK(valFloat == deserializedFloat);
+}
+
+TEST_CASE("Endian-swapped serialization, deserialization of primitives", "[fast] [serialize]") {
+    int64_t val64 = 27837492938;
+    float valFloat = 23.71728;
+    SerializeContext ser1(true, true);
+    SerializePrimitive<int64_t>(&ser1, val64);
+    SerializePrimitive<float>(&ser1, valFloat);
+    DeserializeContext des(ser1.buffer.data());
+    int64_t deserializedVal64 = DeserializePrimitive<int64_t>(&des);
+    float deserializedValFloat = DeserializePrimitive<float>(&des);
+    CHECK(val64 != deserializedVal64);
+    CHECK(valFloat != deserializedValFloat);
+    // but if we serialize it again, it should be back to normal!
+
+    SerializeContext ser2(true, true);
+    SerializePrimitive<int64_t>(&ser2, deserializedVal64);
+    SerializePrimitive<float>(&ser2, deserializedValFloat);
+    DeserializeContext des2(ser2.buffer.data());
+    int64_t redeserializedVal64 = DeserializePrimitive<int64_t>(&des2);
+    float redeserializedValFloat = DeserializePrimitive<float>(&des2);
+    CHECK(val64 == redeserializedVal64);
+    CHECK(valFloat == redeserializedValFloat);
+}
+
+TEST_CASE("Endian-swapped floats only", "[fast] [serialize]") {
+    int64_t val64 = 27837492938;
+    float valFloat = 23.71728;
+    SerializeContext ser1(false, true);
+    SerializePrimitive<int64_t>(&ser1, val64);
+    SerializePrimitive<float>(&ser1, valFloat);
+    DeserializeContext des(ser1.buffer.data());
+    int64_t deserializedVal64 = DeserializePrimitive<int64_t>(&des);
+    float deserializedValFloat = DeserializePrimitive<float>(&des);
+    CHECK(val64 == deserializedVal64);
+    CHECK(valFloat != deserializedValFloat);
+
+    SerializeContext ser2(false, true);
+    SerializePrimitive<float>(&ser2, deserializedValFloat);
+    DeserializeContext des2(ser2.buffer.data());
+    float redeserializedValFloat = DeserializePrimitive<float>(&des2);
+    CHECK(valFloat == redeserializedValFloat);
+}

--- a/test/serialize.cpp
+++ b/test/serialize.cpp
@@ -62,3 +62,38 @@ TEST_CASE("Endian-swapped floats only", "[fast] [serialize]") {
     float redeserializedValFloat = DeserializePrimitive<float>(&des2);
     CHECK(valFloat == redeserializedValFloat);
 }
+
+TEST_CASE("Padding", "[fast] [serialize]") {
+    int8_t val8 = 23;
+    int32_t val32 = 1234567;
+    SerializeContext ser;
+    SerializePrimitive<int8_t>(&ser, val8);
+    SerializePrimitive<int32_t>(&ser, val32);
+    CHECK(ser.buffer.size() == 8);
+    CHECK(ser.buffer[0] == 23);
+    CHECK(ser.buffer[1] == 0);
+    CHECK(ser.buffer[2] == 0);
+    CHECK(ser.buffer[3] == 0);
+
+    DeserializeContext des(ser.buffer.data()+4);
+    int32_t deserializedVal32 = DeserializePrimitive<int32_t>(&des);
+    CHECK(val32 == deserializedVal32);
+}
+
+TEST_CASE("Array", "[fast] [serialize]") {
+    SerializeContext ser;
+    // serialize a single byte first, to ensure that array adds padding.
+    SerializePrimitive<int8_t>(&ser, 42);
+    for (int16_t i = 0; i < 16; i++) {
+        SerializePrimitive<int16_t>(&ser, i);
+    }
+
+    DeserializeContext des(ser.buffer.data());
+    int8_t firstByte = DeserializePrimitive<int8_t>(&des);
+    CHECK(firstByte == 42);
+    const int16_t *arr = DeserializeArray<int16_t>(&des, 8);
+    CHECK(arr[0] == 0);
+    CHECK(arr[1] == 1);
+    int8_t ninthByte = DeserializePrimitive<int16_t>(&des);
+    CHECK(ninthByte == 8);
+}

--- a/test/serialize.cpp
+++ b/test/serialize.cpp
@@ -1,8 +1,8 @@
 // Tests for serialization and multidatabases
 
-#include <catch.hpp>
-
 #include <vector>
+
+#include <catch.hpp>
 
 #include "serialize-helpers.hpp"
 

--- a/test/utils.cpp
+++ b/test/utils.cpp
@@ -1,23 +1,11 @@
 #include "utils.hpp"
 
 #include <algorithm>
+#include <vector>
 
 #include "databases.hpp"
 
 namespace lost {
-
-unsigned char *BuildPairDistanceKVectorDatabase(
-    const Catalog &catalog, long *length, float minDistance, float maxDistance, long numBins) {
-
-    long dummyLength;
-    if (length == NULL)
-        length = &dummyLength;
-
-    *length = SerializeLengthPairDistanceKVector(catalog, minDistance, maxDistance, numBins);
-    unsigned char *result = new unsigned char[*length];
-    SerializePairDistanceKVector(catalog, minDistance, maxDistance, numBins, result);
-    return result;
-}
 
 bool AreStarIdentifiersEquivalent(const StarIdentifiers &ids1, const StarIdentifiers &ids2) {
     if (ids1.size() != ids2.size()) {

--- a/test/utils.hpp
+++ b/test/utils.hpp
@@ -5,7 +5,6 @@
 
 namespace lost {
 
-unsigned char *BuildPairDistanceKVectorDatabase(const Catalog &catalog, long *length, float minDistance, float maxDistance, long numBins);
 /// simple O(n^2) check
 bool AreStarIdentifiersEquivalent(const StarIdentifiers &, const StarIdentifiers &);
 


### PR DESCRIPTION
For the following reasons:

(a), to ensure that values are aligned, which is required for direct reading on many CPU architectures.

(b), to allow endianness to be different from the "source" and "target" machines (the one generating the db and the one consuming it)

(c), to avoid the duality of Serialize* and Serialize*Length functions.

(d), to overall reduce the room for error, by providing [de]serialization template functions that abstract away the pointer wrangling.