### PR TITLE
Add dependency groff to macOS prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ You need Linux or macOS. On Windows, we recommend installing the Windows Subsyst
 - Install [Eigen]("https://formulae.brew.sh/formula/eigen#default") via homebrew `brew install eigen`
     - Locate Eigen files and move them to `vendor/eigen3/Eigen` under the LOST repository
 - Install [groff]("https://formulae.brew.sh/formula/groff#default") via homebrew `brew install groff`
+- If you get errors mentioning 'ASAN' or 'AddressSanitizer', try `make clean` and then `make LOST_DISABLE_ASAN=1` to disable ASAN. See the Linux section above for more details.
 	
 ### Building
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ You need Linux or macOS. On Windows, we recommend installing the Windows Subsyst
 - Install [cairo](https://formulae.brew.sh/formula/cairo#default) via homebrew `brew install cairo`
 - Install [Eigen]("https://formulae.brew.sh/formula/eigen#default") via homebrew `brew install eigen`
     - Locate Eigen files and move them to `vendor/eigen3/Eigen` under the LOST repository
+- Install [groff]("https://formulae.brew.sh/formula/groff#default") via homebrew `brew install groff`
 	
 ### Building
 


### PR DESCRIPTION
Got an error about not having `groff`, and installing it fixed that error.