### PR TITLE
Disable ASAN automatically on make release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,11 @@ endif
 RELEASE_LDFLAGS := $(LDFLAGS)
 
 # debug link flags:
-ifndef LOST_DISABLE_ASAN
+DISABLE_ASAN = $(or $(LOST_DISABLE_ASAN),$(release))
+
+ifeq ($(DISABLE_ASAN),1)
+	LDFLAGS := $(LDFLAGS)
+else
 	LDFLAGS := $(LDFLAGS) -fsanitize=address
 endif
 


### PR DESCRIPTION
Resolves Issue #118.

Just uses a GNU Make `or` to check for the `LOST_DISABLE_ASAN` or the `release` target.