### PR TITLE
Support for NixOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ pyramid-incorrect.dat
 
 # macOS
 .DS_Store
+
+# Nix
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,78 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1722460556,
+        "narHash": "sha256-icgowa4FsmHJ2lH7wGwF95e7fvm7IsSVkhn6yjmHXdA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b87dfeec0dd13dd7bdea01877df48a8d7eb46091",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "release-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,47 @@
+{
+  description = "Open-source Star Tracker";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/release-24.05";
+    flake-utils.url = "github:numtide/flake-utils";
+
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+  };
+
+  outputs = inputs@{ self, nixpkgs, flake-utils, ... }:
+    let
+      overlays = [
+        (final: prev: rec { lost = prev.callPackage ./nix/package.nix { }; })
+      ];
+    in flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = import nixpkgs { inherit overlays system; };
+      in {
+        packages.default = pkgs.lost;
+        packages.lost = pkgs.lost;
+
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            gcc
+            clang-tools
+            gnumake
+            bear
+            gdb
+            valgrind
+            man
+            groff
+            imagemagick
+            cpplint
+            doxygen
+            graphviz
+            unixtools.xxd
+            eigen
+            cairo
+          ];
+        };
+
+        devShell = self.devShells.${system}.default;
+      });
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,29 @@
+{ stdenv, pkgs, lib }:
+
+stdenv.mkDerivation rec {
+  pname = "lost";
+  version = "0.1.0";
+
+  src = ./..;
+
+  nativeBuildInputs = with pkgs; [ gcc gnumake groff unixtools.xxd eigen ];
+
+  buildInputs = with pkgs; [ cairo ];
+
+  dontConfigure = true;
+
+  buildPhase = ''
+    make release
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    mv lost $out/bin/
+  '';
+
+  meta = with lib; {
+    description = "Open-source Star Tracker";
+    homepage = "https://github.com/uwcubesat/lost";
+    license = licenses.mit;
+  };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,12 @@
+(import
+  (
+    let
+      flake-compat = (builtins.fromJSON (builtins.readFile ./flake.lock)).nodes.flake-compat;
+    in
+      fetchTarball {
+        url = "https://github.com/edolstra/flake-compat/archive/${flake-compat.locked.rev}.tar.gz";
+        sha256 = flake-compat.locked.narHash;
+      }
+  )
+  {src = ./.;})
+.shellNix


### PR DESCRIPTION
Add `flake.nix`, `shell.nix` and `nix/package.nix` for a Nix [development shell](https://nix.dev/manual/nix/2.18/command-ref/new-cli/nix3-develop) and packaging.

It's nice to have when working on a Nix system.