### PR TITLE
[setup] Update macOS setup instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,16 @@
-# Copyright (c) 2020 Mark Polyakov, Karen Haining, Muki Kiboigo (If you edit the file, add your name here!)
-# 
+# Copyright (c) 2020 Mark Polyakov, Karen Haining, Muki Kiboigo, Edward Zhang
+# (If you edit the file, add your name here!)
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -36,7 +37,8 @@ TEST_BIN := ./lost-test
 BSC  := bright-star-catalog.tsv
 
 LIBS     := -lcairo
-CXXFLAGS := $(CXXFLAGS) -Ivendor -Isrc -Idocumentation -Wall -Wextra -Wno-missing-field-initializers -pedantic --std=c++11
+CXXFLAGS := $(CXXFLAGS) -Ivendor -I/opt/homebrew/include -Isrc -Idocumentation -Wall -Wextra -Wno-missing-field-initializers -pedantic --std=c++14
+LDFLAGS  := $(LDFLAGS) -L/opt/homebrew/lib
 RELEASE_CXXFLAGS := $(CXXFLAGS) -O3
 # debug flags:
 CXXFLAGS := $(CXXFLAGS) -ggdb -fno-omit-frame-pointer

--- a/README.md
+++ b/README.md
@@ -32,16 +32,18 @@ You need Linux or macOS. On Windows, we recommend installing the Windows Subsyst
   libeigen3-dev`. Elsewhere, download the latest stable release from https://eigen.tuxfamily.org/.
   You can install it system-wide, or just extract it so that the main folder is in
   `vendor/eigen3/Eigen` under the LOST repository.
-  
+
 ### macOS Prerequisites
 
 - Download [Homebrew](https://brew.sh/), run `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"` in terminal
 - Install [cairo](https://formulae.brew.sh/formula/cairo#default) via homebrew `brew install cairo`
 - Install [Eigen]("https://formulae.brew.sh/formula/eigen#default") via homebrew `brew install eigen`
-    - Locate Eigen files and move them to `vendor/eigen3/Eigen` under the LOST repository
 - Install [groff]("https://formulae.brew.sh/formula/groff#default") via homebrew `brew install groff`
+- On Apple Silicon Macs (M1/M2/etc.), Homebrew installs to `/opt/homebrew`, which is not in the
+  compiler's default search path. Add `-I/opt/homebrew/include` to the `CXXFLAGS` line and
+  `-L/opt/homebrew/lib` to the `LDFLAGS` line in the Makefile.
 - If you get errors mentioning 'ASAN' or 'AddressSanitizer', try `make clean` and then `make LOST_DISABLE_ASAN=1` to disable ASAN. See the Linux section above for more details.
-	
+
 ### Building
 
 Clone this repository (`git clone https://github.com/uwcubesat/lost`), then `cd lost`, then
@@ -219,4 +221,3 @@ filter should be decreased.
 <!--   visualizations. Would be really cool to make it work on a phone! -->
 <!-- - [ ] Automatic corruption of images to test noise tolerance. Star removal, false star adding, -->
 <!--   moon and earth and sun adding, optical offset, focal length mismatch. -->
-


### PR DESCRIPTION
- Eigen 3.4.x seems to require C++14, updated Makefile
- Updating README instructions, Mac users can add Homebrew include/lib paths, some people are running into issues here (also avoid having to find/copy over Eigen download)

Tested manually