### PR TITLE
Implement algo registry pattern instead of hardcoding in pipeline-input

### DIFF
--- a/src/algorithm-registry.hpp
+++ b/src/algorithm-registry.hpp
@@ -1,0 +1,53 @@
+#ifndef ALGORITHM_REGISTRY_H
+#define ALGORITHM_REGISTRY_H
+
+#include <string>
+#include <map>
+#include <functional>
+#include <memory>
+
+namespace lost {
+
+class PipelineOptions;
+
+/**
+ * A registry that maps string names to factory functions for a given algorithm base class.
+ * Each algorithm category (centroiding, star-id, attitude estimation) gets its own registry
+ * instance. Algorithms register themselves at static-initialization time in their .cpp files,
+ * so adding a new algorithm never requires modifying SetPipeline().
+ */
+template <typename T>
+class AlgorithmRegistry {
+public:
+    using FactoryFn = std::function<std::unique_ptr<T>(const PipelineOptions &)>;
+
+    static AlgorithmRegistry &Instance() {
+        static AlgorithmRegistry instance;
+        return instance;
+    }
+
+    void Register(const std::string &name, FactoryFn factory) {
+        factories_[name] = std::move(factory);
+    }
+
+    /// Create an algorithm by name, or return nullptr if the name is not registered.
+    std::unique_ptr<T> Create(const std::string &name, const PipelineOptions &options) const {
+        auto it = factories_.find(name);
+        if (it == factories_.end()) {
+            return nullptr;
+        }
+        return it->second(options);
+    }
+
+    bool Has(const std::string &name) const {
+        return factories_.count(name) > 0;
+    }
+
+private:
+    AlgorithmRegistry() = default;
+    std::map<std::string, FactoryFn> factories_;
+};
+
+} // namespace lost
+
+#endif

--- a/src/attitude-estimators.cpp
+++ b/src/attitude-estimators.cpp
@@ -3,7 +3,9 @@
 #include <eigen3/Eigen/Dense>
 #include <eigen3/Eigen/Eigenvalues>
 
+#include "algorithm-registry.hpp"
 #include "decimal.hpp"
+#include "pipeline-input.hpp"
 
 namespace lost {
 
@@ -245,5 +247,23 @@ Attitude QuestAlgorithm::Go(const Camera &camera,
 
     return Attitude(Quaternion(gamma, X.x, X.y, X.z));
 }
+
+static struct AttitudeRegistry {
+    AttitudeRegistry() {
+        auto &reg = AlgorithmRegistry<AttitudeEstimationAlgorithm>::Instance();
+        reg.Register("dqm", [](const PipelineOptions &) {
+            return std::unique_ptr<AttitudeEstimationAlgorithm>(
+                new DavenportQAlgorithm());
+        });
+        reg.Register("triad", [](const PipelineOptions &) {
+            return std::unique_ptr<AttitudeEstimationAlgorithm>(
+                new TriadAlgorithm());
+        });
+        reg.Register("quest", [](const PipelineOptions &) {
+            return std::unique_ptr<AttitudeEstimationAlgorithm>(
+                new QuestAlgorithm());
+        });
+    }
+} attitudeRegistry;
 
 }

--- a/src/centroiders.cpp
+++ b/src/centroiders.cpp
@@ -10,7 +10,9 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include "algorithm-registry.hpp"
 #include "decimal.hpp"
+#include "pipeline-input.hpp"
 
 namespace lost {
 
@@ -323,5 +325,23 @@ Stars IterativeWeightedCenterOfGravityAlgorithm::Go(unsigned char *image, int im
     }
     return result;
 }
+
+static struct CentroidRegistry {
+    CentroidRegistry() {
+        auto &reg = AlgorithmRegistry<CentroidAlgorithm>::Instance();
+        reg.Register("dummy", [](const PipelineOptions &opts) {
+            return std::unique_ptr<CentroidAlgorithm>(
+                new DummyCentroidAlgorithm(opts.centroidDummyNumStars));
+        });
+        reg.Register("cog", [](const PipelineOptions &) {
+            return std::unique_ptr<CentroidAlgorithm>(
+                new CenterOfGravityAlgorithm());
+        });
+        reg.Register("iwcog", [](const PipelineOptions &) {
+            return std::unique_ptr<CentroidAlgorithm>(
+                new IterativeWeightedCenterOfGravityAlgorithm());
+        });
+    }
+} centroidRegistry;
 
 }

--- a/src/pipeline-input.cpp
+++ b/src/pipeline-input.cpp
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <chrono>
 
+#include "algorithm-registry.hpp"
 #include "attitude-estimators.hpp"
 #include "attitude-utils.hpp"
 #include "cairo-utils.hpp"
@@ -531,21 +532,14 @@ Pipeline::Pipeline(CentroidAlgorithm *centroidAlgorithm,
 Pipeline SetPipeline(const PipelineOptions &values) {
     Pipeline result;
 
-    // TODO: more flexible or sth
-    // TODO: don't allow setting star-id until database is set, and perhaps limit the star-id
-    // choices to those compatible with the database?
-    //
-
     // centroid algorithm stage
-    if (values.centroidAlgo == "dummy") {
-        result.centroidAlgorithm = std::unique_ptr<CentroidAlgorithm>(new DummyCentroidAlgorithm(values.centroidDummyNumStars));
-    } else if (values.centroidAlgo == "cog") {
-        result.centroidAlgorithm = std::unique_ptr<CentroidAlgorithm>(new CenterOfGravityAlgorithm());
-    } else if (values.centroidAlgo == "iwcog") {
-        result.centroidAlgorithm = std::unique_ptr<CentroidAlgorithm>(new IterativeWeightedCenterOfGravityAlgorithm());
-    } else if (values.centroidAlgo != "") {
-        std::cout << "Illegal centroid algorithm." << std::endl;
-        exit(1);
+    if (values.centroidAlgo != "") {
+        result.centroidAlgorithm = AlgorithmRegistry<CentroidAlgorithm>::Instance()
+            .Create(values.centroidAlgo, values);
+        if (!result.centroidAlgorithm) {
+            std::cout << "Illegal centroid algorithm." << std::endl;
+            exit(1);
+        }
     }
 
     // centroid magnitude filter stage
@@ -569,26 +563,24 @@ Pipeline SetPipeline(const PipelineOptions &values) {
         std::cerr << "Done" << std::endl;
     }
 
-    if (values.idAlgo == "dummy") {
-        result.starIdAlgorithm = std::unique_ptr<StarIdAlgorithm>(new DummyStarIdAlgorithm());
-    } else if (values.idAlgo == "gv") {
-        result.starIdAlgorithm = std::unique_ptr<StarIdAlgorithm>(new GeometricVotingStarIdAlgorithm(DegToRad(values.angularTolerance)));
-    } else if (values.idAlgo == "py") {
-        result.starIdAlgorithm = std::unique_ptr<StarIdAlgorithm>(new PyramidStarIdAlgorithm(DegToRad(values.angularTolerance), values.estimatedNumFalseStars, values.maxMismatchProb, 1000));
-    } else if (values.idAlgo != "") {
-        std::cout << "Illegal id algorithm." << std::endl;
-        exit(1);
+    // star-id algorithm stage
+    if (values.idAlgo != "") {
+        result.starIdAlgorithm = AlgorithmRegistry<StarIdAlgorithm>::Instance()
+            .Create(values.idAlgo, values);
+        if (!result.starIdAlgorithm) {
+            std::cout << "Illegal id algorithm." << std::endl;
+            exit(1);
+        }
     }
 
-    if (values.attitudeAlgo == "dqm") {
-        result.attitudeEstimationAlgorithm = std::unique_ptr<AttitudeEstimationAlgorithm>(new DavenportQAlgorithm());
-    } else if (values.attitudeAlgo == "triad") {
-        result.attitudeEstimationAlgorithm = std::unique_ptr<AttitudeEstimationAlgorithm>(new TriadAlgorithm());
-    } else if (values.attitudeAlgo == "quest") {
-        result.attitudeEstimationAlgorithm = std::unique_ptr<AttitudeEstimationAlgorithm>(new QuestAlgorithm());
-    } else if (values.attitudeAlgo != "") {
-        std::cout << "Illegal attitude algorithm." << std::endl;
-        exit(1);
+    // attitude estimation algorithm stage
+    if (values.attitudeAlgo != "") {
+        result.attitudeEstimationAlgorithm = AlgorithmRegistry<AttitudeEstimationAlgorithm>::Instance()
+            .Create(values.attitudeAlgo, values);
+        if (!result.attitudeEstimationAlgorithm) {
+            std::cout << "Illegal attitude algorithm." << std::endl;
+            exit(1);
+        }
     }
 
     return result;

--- a/src/star-id.cpp
+++ b/src/star-id.cpp
@@ -8,8 +8,10 @@
 
 #include "star-id.hpp"
 #include "star-id-private.hpp"
+#include "algorithm-registry.hpp"
 #include "databases.hpp"
 #include "attitude-utils.hpp"
+#include "pipeline-input.hpp"
 
 namespace lost {
 
@@ -768,5 +770,26 @@ StarIdentifiers PyramidStarIdAlgorithm::Go(
     std::cerr << "Tried all pyramids; none matched." << std::endl;
     return identified;
 }
+
+static struct StarIdRegistry {
+    StarIdRegistry() {
+        auto &reg = AlgorithmRegistry<StarIdAlgorithm>::Instance();
+        reg.Register("dummy", [](const PipelineOptions &) {
+            return std::unique_ptr<StarIdAlgorithm>(
+                new DummyStarIdAlgorithm());
+        });
+        reg.Register("gv", [](const PipelineOptions &opts) {
+            return std::unique_ptr<StarIdAlgorithm>(
+                new GeometricVotingStarIdAlgorithm(DegToRad(opts.angularTolerance)));
+        });
+        reg.Register("py", [](const PipelineOptions &opts) {
+            return std::unique_ptr<StarIdAlgorithm>(
+                new PyramidStarIdAlgorithm(DegToRad(opts.angularTolerance),
+                                           opts.estimatedNumFalseStars,
+                                           opts.maxMismatchProb,
+                                           1000));
+        });
+    }
+} starIdRegistry;
 
 }


### PR DESCRIPTION
Proposing this pattern so users don't need to go modify `pipeline-input` to enable their algo in the pipeline, instead redirecting to `centroiders.cpp`, `star-id.cpp`, or `attitude-estimators.cpp` to register new algo